### PR TITLE
call export function test implemented

### DIFF
--- a/test/deps/binaryen/binaryen_test.cpp
+++ b/test/deps/binaryen/binaryen_test.cpp
@@ -76,7 +76,11 @@ TEST(BinaryenTest, InvokeCppFunctionFromWebAssembly) {
 
   // parse wast
   Module wasm{};
-  SExpressionParser parser(expression.data());
+
+  // clang-8 doesn't know char * std::string::data(),
+  // it returns only const char *
+  char *data = const_cast<char *>(expression.data());
+  SExpressionParser parser(data);
   Element &root = *parser.root;
   SExpressionWasmBuilder builder(wasm, *root[0]);
 

--- a/test/deps/binaryen/binaryen_test.cpp
+++ b/test/deps/binaryen/binaryen_test.cpp
@@ -72,12 +72,7 @@ TEST(BinaryenTest, InvokeCppFunctionFromWebAssembly) {
               )#")
           % env_name % fun_name % expected_argument;
 
-  std::string add_wast = fmt.str();
-  size_t length = add_wast.size();
-
-  // make a safe char* array copy
-  std::vector<char> expression(length + 1, '\0');
-  strncpy(expression.data(), add_wast.data(), length);
+  std::string expression = fmt.str();
 
   // parse wast
   Module wasm{};
@@ -115,8 +110,8 @@ TEST(BinaryenTest, InvokeWebAssemblyFunctionFromCpp) {
           )#";
 
   // parse wast
-  SExpressionParser parser(const_cast<char *>(sexpr));
-  auto &root = *parser.root;
+  SExpressionParser parser(sexpr);
+  auto & root = *parser.root;
 
   // wasm
   Module wasm{};
@@ -131,7 +126,6 @@ TEST(BinaryenTest, InvokeWebAssemblyFunctionFromCpp) {
   ModuleInstance moduleInstance(wasm, &shellInterface);
 
   // add arguments, their constructors are explicit, so no list-initialization
-  // for them
   LiteralList arguments = {Literal{1}, Literal{2}};
 
   // call exported function

--- a/test/deps/binaryen/binaryen_test.cpp
+++ b/test/deps/binaryen/binaryen_test.cpp
@@ -58,7 +58,7 @@ TEST(BinaryenTest, InvokeCppFunctionFromWebAssembly) {
 
   // wast code with imported function's call
   auto fmt = boost::format(
-              R"#(
+                 R"#(
               (module
                 (type $v (func))
                 (import "%1%" "%2%" (func $%2% (param i32)))
@@ -70,7 +70,7 @@ TEST(BinaryenTest, InvokeCppFunctionFromWebAssembly) {
                 )
               )
               )#")
-          % env_name % fun_name % expected_argument;
+      % env_name % fun_name % expected_argument;
 
   std::string expression = fmt.str();
 
@@ -89,7 +89,8 @@ TEST(BinaryenTest, InvokeCppFunctionFromWebAssembly) {
 
 /**
  * @given WebAssembly S-expression code exporting a function
- * exported function (sumtwo) taking two arguments of type i32 returning their sum of type i32 is implemented in assembly
+ * exported function (sumtwo) taking two arguments of type i32 returning their
+ * sum of type i32 is implemented in assembly
  * @when this code is interpreted using Binaryen
  * @then sumtwo implementation on wasm is invoked from C++ with given arguments
  * and returns result (the sum of two i32) back to C++ code
@@ -111,7 +112,7 @@ TEST(BinaryenTest, InvokeWebAssemblyFunctionFromCpp) {
 
   // parse wast
   SExpressionParser parser(sexpr);
-  auto & root = *parser.root;
+  auto &root = *parser.root;
 
   // wasm
   Module wasm{};

--- a/test/deps/binaryen/binaryen_test.cpp
+++ b/test/deps/binaryen/binaryen_test.cpp
@@ -95,9 +95,9 @@ TEST(BinaryenTest, InvokeCppFunctionFromWebAssembly) {
  * @given WebAssembly S-expression code exporting a function
  * exported function (sumtwo) taking two arguments of type i32 returning their
  * sum of type i32 is implemented in assembly
- * @when this code is interpreted using Binaryen
- * @then sumtwo implementation on wasm is invoked from C++ with given arguments
- * and returns result (the sum of two i32) back to C++ code
+ * @when this code is interpreted using Binaryen and invoked from C++ with given
+ * arguments
+ * @then result (the sum of two i32) is calculated and returned to C++ code
  */
 TEST(BinaryenTest, InvokeWebAssemblyFunctionFromCpp) {
   // wast code with imported function's call


### PR DESCRIPTION
Binaryen allows calling wasm export functions from C++.
I implemented a test case demonstrating this feature.