### PR TITLE
Extensions interfaces

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,8 +4,8 @@ BreakBeforeBinaryOperators: NonAssignment
 AlignOperands: false
 DerivePointerAlignment: false
 PointerAlignment: Right
-BinPackArguments: false
-BinPackParameters: false
+BinPackArguments: true
+BinPackParameters: true
 DerivePointerAlignment: false
 PointerAlignment: Right
 AllowShortFunctionsOnASingleLine: Empty

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -6,3 +6,4 @@
 add_subdirectory(common)
 add_subdirectory(libp2p)
 add_subdirectory(crypto)
+add_subdirectory(extensions)

--- a/core/extensions/CMakeLists.txt
+++ b/core/extensions/CMakeLists.txt
@@ -1,0 +1,8 @@
+#
+# Copyright Soramitsu Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+add_library(extensions
+    extension_impl.cpp
+    )

--- a/core/extensions/CMakeLists.txt
+++ b/core/extensions/CMakeLists.txt
@@ -5,4 +5,10 @@
 
 add_library(extensions
     extension_impl.cpp
+    impl/crypto_extension.cpp
+    impl/io_extension.cpp
+    impl/memory_extension.cpp
+    impl/misc_extension.cpp
+    impl/sandboxing_extension.cpp
+    impl/storage_extension.cpp
     )

--- a/core/extensions/extension.hpp
+++ b/core/extensions/extension.hpp
@@ -1,0 +1,140 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_EXTENSION_HPP
+#define KAGOME_EXTENSION_HPP
+
+#include <functional>
+
+namespace extensions {
+  /**
+   * Extensions for WASM; API, which is called by the runtime to control RE
+   */
+  class Extension {
+   public:
+    /// storage extensions
+    virtual uint8_t *ext_child_storage_root(const uint8_t *storage_key_data,
+                                            uint32_t storage_key_length,
+                                            uint32_t *written) = 0;
+    virtual void ext_clear_child_storage(const uint8_t *storage_key_data,
+                                         uint32_t storage_key_length,
+                                         const uint8_t *key_data,
+                                         uint32_t key_length) = 0;
+    virtual void ext_clear_prefix(const uint8_t *prefix_data,
+                                  uint32_t prefix_length) = 0;
+    virtual void ext_clear_storage(const uint8_t *key_data,
+                                   uint32_t key_length) = 0;
+    virtual uint32_t ext_exists_child_storage(const uint8_t *storage_key_data,
+                                              uint32_t storage_key_length,
+                                              const uint8_t *key_data,
+                                              uint32_t key_length) = 0;
+    virtual uint8_t *ext_get_allocated_child_storage(
+        const uint8_t *storage_key_data,
+        uint32_t storage_key_length,
+        const uint8_t *key_data,
+        uint32_t key_length,
+        uint32_t *written) = 0;
+    virtual uint8_t *ext_get_allocated_storage(const uint8_t *key_data,
+                                               uint32_t key_length,
+                                               uint32_t *written) = 0;
+    virtual uint32_t ext_get_child_storage_into(const uint8_t *storage_key_data,
+                                                uint32_t storage_key_length,
+                                                const uint8_t *key_data,
+                                                uint32_t key_length,
+                                                uint8_t *value_data,
+                                                uint32_t value_length,
+                                                uint32_t value_offset) = 0;
+    virtual uint32_t ext_get_storage_into(const uint8_t *key_data,
+                                          uint32_t key_length,
+                                          uint8_t *value_data,
+                                          uint32_t value_length,
+                                          uint32_t value_offset) = 0;
+    virtual void ext_kill_child_storage(const uint8_t *storage_key_data,
+                                        uint32_t storage_key_length) = 0;
+    virtual void ext_set_child_storage(const uint8_t *storage_key_data,
+                                       uint32_t storage_key_length,
+                                       const uint8_t *key_data,
+                                       uint32_t key_length,
+                                       uint8_t *value_data,
+                                       uint32_t value_length) = 0;
+    virtual void ext_set_storage(const uint8_t *key_data,
+                                 uint32_t key_length,
+                                 uint8_t *value_data,
+                                 uint32_t value_length) = 0;
+    virtual uint32_t ext_storage_changes_root(const uint8_t *parent_hash_data,
+                                              uint32_t parent_hash_len,
+                                              uint64_t parent_num,
+                                              uint8_t *result) = 0;
+    virtual void ext_storage_root(uint8_t *result) = 0;
+    virtual uint32_t ext_exists_storage(const uint8_t *key_data,
+                                        uint32_t key_length) = 0;
+
+    /// memory extensions
+    virtual uint8_t *ext_malloc(uint32_t size) = 0;
+    virtual void ext_free(uint8_t *ptr) = 0;
+
+    /// I/O extensions
+    virtual void ext_print_hex(const uint8_t *data, uint32_t length) = 0;
+    virtual void ext_print_num(uint64_t value) = 0;
+    virtual void ext_print_utf8(const uint8_t *utf8_data,
+                                uint32_t utf8_length) = 0;
+
+    /// cryptographic extensions
+    virtual void ext_blake2_256(const uint8_t *data,
+                                uint32_t len,
+                                uint8_t *out) = 0;
+    virtual void ext_blake2_256_enumerated_trie_root(const uint8_t *values_data,
+                                                     const uint32_t *lens_data,
+                                                     uint32_t lens_length,
+                                                     uint8_t *result) = 0;
+    virtual uint32_t ext_ed25519_verify(const uint8_t *msg_data,
+                                        uint32_t msg_len,
+                                        const uint8_t *sig_data,
+                                        const uint8_t *pubkey_data) = 0;
+    virtual void ext_twox_128(const uint8_t *data,
+                              uint32_t len,
+                              uint8_t *out) = 0;
+    virtual void ext_twox_256(const uint8_t *data,
+                              uint32_t len,
+                              uint8_t *out) = 0;
+
+    /// sandboxing extensions
+    virtual void ext_sandbox_instance_teardown(uint32_t instance_idx) = 0;
+    virtual uint32_t ext_sandbox_instantiate(
+        std::function<uint64_t(const uint8_t *serialized_args,
+                               uint32_t serialized_args_length,
+                               uint32_t state,
+                               uint32_t func_index)> dispatch_func,
+        const uint8_t *wasm_ptr,
+        uint32_t wasm_length,
+        const uint8_t *imports_ptr,
+        uint32_t imports_length,
+        uint32_t state) = 0;
+    virtual uint32_t ext_sandbox_invoke(uint32_t instance_idx,
+                                        const uint8_t *export_ptr,
+                                        uint32_t export_len,
+                                        const uint8_t *args_ptr,
+                                        uint32_t args_len,
+                                        uint8_t *return_val_ptr,
+                                        uint32_t return_val_len,
+                                        uint32_t state) = 0;
+    virtual uint32_t ext_sandbox_memory_get(uint32_t memory_idx,
+                                            uint32_t offset,
+                                            uint8_t *buf_ptr,
+                                            uint32_t buf_length) = 0;
+    virtual uint32_t ext_sandbox_memory_new(uint32_t initial,
+                                            uint32_t maximum) = 0;
+    virtual uint32_t ext_sandbox_memory_set(uint32_t memory_idx,
+                                            uint32_t offset,
+                                            const uint8_t *val_ptr,
+                                            uint32_t val_len) = 0;
+    virtual void ext_sandbox_memory_teardown(uint32_t memory_idx) = 0;
+
+    /// misc extensions
+    virtual uint64_t ext_chain_id() = 0;
+  };
+}  // namespace extensions
+
+#endif  // KAGOME_EXTENSION_HPP

--- a/core/extensions/extension.hpp
+++ b/core/extensions/extension.hpp
@@ -9,7 +9,7 @@
 #include <cstdint>
 #include <functional>
 
-namespace extensions {
+namespace kagome::extensions {
   /**
    * Extensions for WASM; API, which is called by the runtime to control RE
    */
@@ -121,7 +121,7 @@ namespace extensions {
     virtual void ext_sandbox_instance_teardown(uint32_t instance_idx) = 0;
 
     virtual uint32_t ext_sandbox_instantiate(
-        SandoxDispatchFuncType dispatch_func, const uint8_t *wasm_ptr,
+        const SandoxDispatchFuncType &dispatch_func, const uint8_t *wasm_ptr,
         size_t wasm_length, const uint8_t *imports_ptr, size_t imports_length,
         size_t state) = 0;
 

--- a/core/extensions/extension.hpp
+++ b/core/extensions/extension.hpp
@@ -14,123 +14,134 @@ namespace extensions {
    * Extensions for WASM; API, which is called by the runtime to control RE
    */
   class Extension {
+   protected:
+    using SandoxDispatchFuncType = std::function<uint64_t(
+        const uint8_t *serialized_args, size_t serialized_args_length,
+        size_t state, size_t func_index)>;
+
    public:
     /// storage extensions
     virtual uint8_t *ext_child_storage_root(const uint8_t *storage_key_data,
                                             uint32_t storage_key_length,
                                             uint32_t *written) = 0;
+
     virtual void ext_clear_child_storage(const uint8_t *storage_key_data,
                                          uint32_t storage_key_length,
                                          const uint8_t *key_data,
                                          uint32_t key_length) = 0;
+
     virtual void ext_clear_prefix(const uint8_t *prefix_data,
                                   uint32_t prefix_length) = 0;
+
     virtual void ext_clear_storage(const uint8_t *key_data,
                                    uint32_t key_length) = 0;
+
     virtual uint32_t ext_exists_child_storage(const uint8_t *storage_key_data,
                                               uint32_t storage_key_length,
                                               const uint8_t *key_data,
                                               uint32_t key_length) = 0;
+
     virtual uint8_t *ext_get_allocated_child_storage(
-        const uint8_t *storage_key_data,
-        uint32_t storage_key_length,
-        const uint8_t *key_data,
-        uint32_t key_length,
-        uint32_t *written) = 0;
+        const uint8_t *storage_key_data, uint32_t storage_key_length,
+        const uint8_t *key_data, uint32_t key_length, uint32_t *written) = 0;
+
     virtual uint8_t *ext_get_allocated_storage(const uint8_t *key_data,
                                                uint32_t key_length,
                                                uint32_t *written) = 0;
-    virtual uint32_t ext_get_child_storage_into(const uint8_t *storage_key_data,
-                                                uint32_t storage_key_length,
-                                                const uint8_t *key_data,
-                                                uint32_t key_length,
-                                                uint8_t *value_data,
-                                                uint32_t value_length,
-                                                uint32_t value_offset) = 0;
+
+    virtual uint32_t ext_get_child_storage_into(
+        const uint8_t *storage_key_data, uint32_t storage_key_length,
+        const uint8_t *key_data, uint32_t key_length, uint8_t *value_data,
+        uint32_t value_length, uint32_t value_offset) = 0;
+
     virtual uint32_t ext_get_storage_into(const uint8_t *key_data,
                                           uint32_t key_length,
                                           uint8_t *value_data,
                                           uint32_t value_length,
                                           uint32_t value_offset) = 0;
+
     virtual void ext_kill_child_storage(const uint8_t *storage_key_data,
                                         uint32_t storage_key_length) = 0;
+
     virtual void ext_set_child_storage(const uint8_t *storage_key_data,
                                        uint32_t storage_key_length,
                                        const uint8_t *key_data,
                                        uint32_t key_length,
                                        const uint8_t *value_data,
                                        uint32_t value_length) = 0;
-    virtual void ext_set_storage(const uint8_t *key_data,
-                                 uint32_t key_length,
+
+    virtual void ext_set_storage(const uint8_t *key_data, uint32_t key_length,
                                  const uint8_t *value_data,
                                  uint32_t value_length) = 0;
+
     virtual uint32_t ext_storage_changes_root(const uint8_t *parent_hash_data,
                                               uint32_t parent_hash_len,
                                               uint64_t parent_num,
                                               uint8_t *result) = 0;
+
     virtual void ext_storage_root(uint8_t *result) = 0;
+
     virtual uint32_t ext_exists_storage(const uint8_t *key_data,
                                         uint32_t key_length) = 0;
 
     /// memory extensions
     virtual uint8_t *ext_malloc(uint32_t size) = 0;
+
     virtual void ext_free(uint8_t *ptr) = 0;
 
     /// I/O extensions
     virtual void ext_print_hex(const uint8_t *data, uint32_t length) = 0;
+
     virtual void ext_print_num(uint64_t value) = 0;
+
     virtual void ext_print_utf8(const uint8_t *utf8_data,
                                 uint32_t utf8_length) = 0;
 
     /// cryptographic extensions
-    virtual void ext_blake2_256(const uint8_t *data,
-                                uint32_t len,
+    virtual void ext_blake2_256(const uint8_t *data, uint32_t len,
                                 uint8_t *out) = 0;
+
     virtual void ext_blake2_256_enumerated_trie_root(const uint8_t *values_data,
                                                      const uint32_t *lens_data,
                                                      uint32_t lens_length,
                                                      uint8_t *result) = 0;
+
     virtual uint32_t ext_ed25519_verify(const uint8_t *msg_data,
                                         uint32_t msg_len,
                                         const uint8_t *sig_data,
                                         const uint8_t *pubkey_data) = 0;
-    virtual void ext_twox_128(const uint8_t *data,
-                              uint32_t len,
+
+    virtual void ext_twox_128(const uint8_t *data, uint32_t len,
                               uint8_t *out) = 0;
-    virtual void ext_twox_256(const uint8_t *data,
-                              uint32_t len,
+
+    virtual void ext_twox_256(const uint8_t *data, uint32_t len,
                               uint8_t *out) = 0;
 
     /// sandboxing extensions
     virtual void ext_sandbox_instance_teardown(uint32_t instance_idx) = 0;
+
     virtual uint32_t ext_sandbox_instantiate(
-        std::function<uint64_t(const uint8_t *serialized_args,
-                               size_t serialized_args_length,
-                               size_t state,
-                               size_t func_index)> dispatch_func,
-        const uint8_t *wasm_ptr,
-        size_t wasm_length,
-        const uint8_t *imports_ptr,
-        size_t imports_length,
+        SandoxDispatchFuncType dispatch_func, const uint8_t *wasm_ptr,
+        size_t wasm_length, const uint8_t *imports_ptr, size_t imports_length,
         size_t state) = 0;
-    virtual uint32_t ext_sandbox_invoke(uint32_t instance_idx,
-                                        const uint8_t *export_ptr,
-                                        size_t export_len,
-                                        const uint8_t *args_ptr,
-                                        size_t args_len,
-                                        uint8_t *return_val_ptr,
-                                        size_t return_val_len,
-                                        size_t state) = 0;
+
+    virtual uint32_t ext_sandbox_invoke(
+        uint32_t instance_idx, const uint8_t *export_ptr, size_t export_len,
+        const uint8_t *args_ptr, size_t args_len, uint8_t *return_val_ptr,
+        size_t return_val_len, size_t state) = 0;
+
     virtual uint32_t ext_sandbox_memory_get(uint32_t memory_idx,
-                                            uint32_t offset,
-                                            uint8_t *buf_ptr,
+                                            uint32_t offset, uint8_t *buf_ptr,
                                             size_t buf_length) = 0;
+
     virtual uint32_t ext_sandbox_memory_new(uint32_t initial,
                                             uint32_t maximum) = 0;
+
     virtual uint32_t ext_sandbox_memory_set(uint32_t memory_idx,
                                             uint32_t offset,
                                             const uint8_t *val_ptr,
                                             size_t val_len) = 0;
+
     virtual void ext_sandbox_memory_teardown(uint32_t memory_idx) = 0;
 
     /// misc extensions

--- a/core/extensions/extension.hpp
+++ b/core/extensions/extension.hpp
@@ -6,6 +6,7 @@
 #ifndef KAGOME_EXTENSION_HPP
 #define KAGOME_EXTENSION_HPP
 
+#include <cstdint>
 #include <functional>
 
 namespace extensions {
@@ -57,11 +58,11 @@ namespace extensions {
                                        uint32_t storage_key_length,
                                        const uint8_t *key_data,
                                        uint32_t key_length,
-                                       uint8_t *value_data,
+                                       const uint8_t *value_data,
                                        uint32_t value_length) = 0;
     virtual void ext_set_storage(const uint8_t *key_data,
                                  uint32_t key_length,
-                                 uint8_t *value_data,
+                                 const uint8_t *value_data,
                                  uint32_t value_length) = 0;
     virtual uint32_t ext_storage_changes_root(const uint8_t *parent_hash_data,
                                               uint32_t parent_hash_len,
@@ -104,32 +105,32 @@ namespace extensions {
     virtual void ext_sandbox_instance_teardown(uint32_t instance_idx) = 0;
     virtual uint32_t ext_sandbox_instantiate(
         std::function<uint64_t(const uint8_t *serialized_args,
-                               uint32_t serialized_args_length,
-                               uint32_t state,
-                               uint32_t func_index)> dispatch_func,
+                               size_t serialized_args_length,
+                               size_t state,
+                               size_t func_index)> dispatch_func,
         const uint8_t *wasm_ptr,
-        uint32_t wasm_length,
+        size_t wasm_length,
         const uint8_t *imports_ptr,
-        uint32_t imports_length,
-        uint32_t state) = 0;
+        size_t imports_length,
+        size_t state) = 0;
     virtual uint32_t ext_sandbox_invoke(uint32_t instance_idx,
                                         const uint8_t *export_ptr,
-                                        uint32_t export_len,
+                                        size_t export_len,
                                         const uint8_t *args_ptr,
-                                        uint32_t args_len,
+                                        size_t args_len,
                                         uint8_t *return_val_ptr,
-                                        uint32_t return_val_len,
-                                        uint32_t state) = 0;
+                                        size_t return_val_len,
+                                        size_t state) = 0;
     virtual uint32_t ext_sandbox_memory_get(uint32_t memory_idx,
                                             uint32_t offset,
                                             uint8_t *buf_ptr,
-                                            uint32_t buf_length) = 0;
+                                            size_t buf_length) = 0;
     virtual uint32_t ext_sandbox_memory_new(uint32_t initial,
                                             uint32_t maximum) = 0;
     virtual uint32_t ext_sandbox_memory_set(uint32_t memory_idx,
                                             uint32_t offset,
                                             const uint8_t *val_ptr,
-                                            uint32_t val_len) = 0;
+                                            size_t val_len) = 0;
     virtual void ext_sandbox_memory_teardown(uint32_t memory_idx) = 0;
 
     /// misc extensions

--- a/core/extensions/extension_impl.cpp
+++ b/core/extensions/extension_impl.cpp
@@ -84,7 +84,7 @@ namespace extensions {
                                             uint32_t storage_key_length,
                                             const uint8_t *key_data,
                                             uint32_t key_length,
-                                            uint8_t *value_data,
+                                            const uint8_t *value_data,
                                             uint32_t value_length) {
     storage_ext_.ext_set_child_storage(storage_key_data,
                                        storage_key_length,
@@ -95,7 +95,7 @@ namespace extensions {
   }
   void ExtensionImpl::ext_set_storage(const uint8_t *key_data,
                                       uint32_t key_length,
-                                      uint8_t *value_data,
+                                      const uint8_t *value_data,
                                       uint32_t value_length) {
     storage_ext_.ext_set_storage(
         key_data, key_length, value_data, value_length);

--- a/core/extensions/extension_impl.cpp
+++ b/core/extensions/extension_impl.cpp
@@ -5,7 +5,7 @@
 
 #include "extensions/extension_impl.hpp"
 
-namespace extensions {
+namespace kagome::extensions {
   /// storage extensions
   uint8_t *ExtensionImpl::ext_child_storage_root(
       const uint8_t *storage_key_data, uint32_t storage_key_length,
@@ -171,7 +171,7 @@ namespace extensions {
   }
 
   uint32_t ExtensionImpl::ext_sandbox_instantiate(
-      SandoxDispatchFuncType dispatch_func, const uint8_t *wasm_ptr,
+      const SandoxDispatchFuncType &dispatch_func, const uint8_t *wasm_ptr,
       size_t wasm_length, const uint8_t *imports_ptr, size_t imports_length,
       size_t state) {
     return sandboxing_ext_.ext_sandbox_instantiate(dispatch_func, wasm_ptr,

--- a/core/extensions/extension_impl.cpp
+++ b/core/extensions/extension_impl.cpp
@@ -1,0 +1,235 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "extensions/extension_impl.hpp"
+
+namespace extensions {
+  /// storage extensions
+  uint8_t *ExtensionImpl::ext_child_storage_root(
+      const uint8_t *storage_key_data,
+      uint32_t storage_key_length,
+      uint32_t *written) {
+    return storage_ext_.ext_child_storage_root(
+        storage_key_data, storage_key_length, written);
+  }
+  void ExtensionImpl::ext_clear_child_storage(const uint8_t *storage_key_data,
+                                              uint32_t storage_key_length,
+                                              const uint8_t *key_data,
+                                              uint32_t key_length) {
+    storage_ext_.ext_clear_child_storage(
+        storage_key_data, storage_key_length, key_data, key_length);
+  }
+  void ExtensionImpl::ext_clear_prefix(const uint8_t *prefix_data,
+                                       uint32_t prefix_length) {
+    storage_ext_.ext_clear_prefix(prefix_data, prefix_length);
+  }
+  void ExtensionImpl::ext_clear_storage(const uint8_t *key_data,
+                                        uint32_t key_length) {
+    storage_ext_.ext_clear_storage(key_data, key_length);
+  }
+  uint32_t ExtensionImpl::ext_exists_child_storage(
+      const uint8_t *storage_key_data,
+      uint32_t storage_key_length,
+      const uint8_t *key_data,
+      uint32_t key_length) {
+    return storage_ext_.ext_exists_child_storage(
+        storage_key_data, storage_key_length, key_data, key_length);
+  }
+  uint8_t *ExtensionImpl::ext_get_allocated_child_storage(
+      const uint8_t *storage_key_data,
+      uint32_t storage_key_length,
+      const uint8_t *key_data,
+      uint32_t key_length,
+      uint32_t *written) {
+    return storage_ext_.ext_get_allocated_child_storage(
+        storage_key_data, storage_key_length, key_data, key_length, written);
+  }
+  uint8_t *ExtensionImpl::ext_get_allocated_storage(const uint8_t *key_data,
+                                                    uint32_t key_length,
+                                                    uint32_t *written) {
+    return storage_ext_.ext_get_allocated_storage(
+        key_data, key_length, written);
+  }
+  uint32_t ExtensionImpl::ext_get_child_storage_into(
+      const uint8_t *storage_key_data,
+      uint32_t storage_key_length,
+      const uint8_t *key_data,
+      uint32_t key_length,
+      uint8_t *value_data,
+      uint32_t value_length,
+      uint32_t value_offset) {
+    return storage_ext_.ext_get_child_storage_into(storage_key_data,
+                                                   storage_key_length,
+                                                   key_data,
+                                                   key_length,
+                                                   value_data,
+                                                   value_length,
+                                                   value_offset);
+  }
+  uint32_t ExtensionImpl::ext_get_storage_into(const uint8_t *key_data,
+                                               uint32_t key_length,
+                                               uint8_t *value_data,
+                                               uint32_t value_length,
+                                               uint32_t value_offset) {
+    return storage_ext_.ext_get_storage_into(
+        key_data, key_length, value_data, value_length, value_offset);
+  }
+  void ExtensionImpl::ext_kill_child_storage(const uint8_t *storage_key_data,
+                                             uint32_t storage_key_length) {
+    storage_ext_.ext_kill_child_storage(storage_key_data, storage_key_length);
+  }
+  void ExtensionImpl::ext_set_child_storage(const uint8_t *storage_key_data,
+                                            uint32_t storage_key_length,
+                                            const uint8_t *key_data,
+                                            uint32_t key_length,
+                                            uint8_t *value_data,
+                                            uint32_t value_length) {
+    storage_ext_.ext_set_child_storage(storage_key_data,
+                                       storage_key_length,
+                                       key_data,
+                                       key_length,
+                                       value_data,
+                                       value_length);
+  }
+  void ExtensionImpl::ext_set_storage(const uint8_t *key_data,
+                                      uint32_t key_length,
+                                      uint8_t *value_data,
+                                      uint32_t value_length) {
+    storage_ext_.ext_set_storage(
+        key_data, key_length, value_data, value_length);
+  }
+  uint32_t ExtensionImpl::ext_storage_changes_root(
+      const uint8_t *parent_hash_data,
+      uint32_t parent_hash_len,
+      uint64_t parent_num,
+      uint8_t *result) {
+    return storage_ext_.ext_storage_changes_root(
+        parent_hash_data, parent_hash_len, parent_num, result);
+  }
+  void ExtensionImpl::ext_storage_root(uint8_t *result) {
+    storage_ext_.ext_storage_root(result);
+  }
+  uint32_t ExtensionImpl::ext_exists_storage(const uint8_t *key_data,
+                                             uint32_t key_length) {
+    return storage_ext_.ext_exists_storage(key_data, key_length);
+  }
+
+  /// memory extensions
+  uint8_t *ExtensionImpl::ext_malloc(uint32_t size) {
+    return memory_ext_.ext_malloc(size);
+  }
+  void ExtensionImpl::ext_free(uint8_t *ptr) {
+    memory_ext_.ext_free(ptr);
+  }
+
+  /// I/O extensions
+  void ExtensionImpl::ext_print_hex(const uint8_t *data, uint32_t length) {
+    io_ext_.ext_print_hex(data, length);
+  }
+  void ExtensionImpl::ext_print_num(uint64_t value) {
+    io_ext_.ext_print_num(value);
+  }
+  void ExtensionImpl::ext_print_utf8(const uint8_t *utf8_data,
+                                     uint32_t utf8_length) {
+    io_ext_.ext_print_utf8(utf8_data, utf8_length);
+  }
+
+  /// cryptographic extensions
+  void ExtensionImpl::ext_blake2_256(const uint8_t *data,
+                                     uint32_t len,
+                                     uint8_t *out) {
+    crypto_ext_.ext_blake2_256(data, len, out);
+  }
+  void ExtensionImpl::ext_blake2_256_enumerated_trie_root(
+      const uint8_t *values_data,
+      const uint32_t *lens_data,
+      uint32_t lens_length,
+      uint8_t *result) {
+    crypto_ext_.ext_blake2_256_enumerated_trie_root(
+        values_data, lens_data, lens_length, result);
+  }
+  uint32_t ExtensionImpl::ext_ed25519_verify(const uint8_t *msg_data,
+                                             uint32_t msg_len,
+                                             const uint8_t *sig_data,
+                                             const uint8_t *pubkey_data) {
+    return crypto_ext_.ext_ed25519_verify(
+        msg_data, msg_len, sig_data, pubkey_data);
+  }
+  void ExtensionImpl::ext_twox_128(const uint8_t *data,
+                                   uint32_t len,
+                                   uint8_t *out) {
+    crypto_ext_.ext_twox_128(data, len, out);
+  }
+  void ExtensionImpl::ext_twox_256(const uint8_t *data,
+                                   uint32_t len,
+                                   uint8_t *out) {
+    crypto_ext_.ext_twox_256(data, len, out);
+  }
+
+  /// sandboxing extensions
+  void ExtensionImpl::ext_sandbox_instance_teardown(uint32_t instance_idx) {
+    sandboxing_ext_.ext_sandbox_instance_teardown(instance_idx);
+  }
+  uint32_t ExtensionImpl::ext_sandbox_instantiate(
+      std::function<uint64_t(const uint8_t *serialized_args,
+                             uint32_t serialized_args_length,
+                             uint32_t state,
+                             uint32_t func_index)> dispatch_func,
+      const uint8_t *wasm_ptr,
+      uint32_t wasm_length,
+      const uint8_t *imports_ptr,
+      uint32_t imports_length,
+      uint32_t state) {
+    return sandboxing_ext_.ext_sandbox_instantiate(dispatch_func,
+                                                   wasm_ptr,
+                                                   wasm_length,
+                                                   imports_ptr,
+                                                   imports_length,
+                                                   state);
+  }
+  uint32_t ExtensionImpl::ext_sandbox_invoke(uint32_t instance_idx,
+                                             const uint8_t *export_ptr,
+                                             uint32_t export_len,
+                                             const uint8_t *args_ptr,
+                                             uint32_t args_len,
+                                             uint8_t *return_val_ptr,
+                                             uint32_t return_val_len,
+                                             uint32_t state) {
+    return sandboxing_ext_.ext_sandbox_invoke(instance_idx,
+                                              export_ptr,
+                                              export_len,
+                                              args_ptr,
+                                              args_len,
+                                              return_val_ptr,
+                                              return_val_len,
+                                              state);
+  }
+  uint32_t ExtensionImpl::ext_sandbox_memory_get(uint32_t memory_idx,
+                                                 uint32_t offset,
+                                                 uint8_t *buf_ptr,
+                                                 uint32_t buf_length) {
+    return sandboxing_ext_.ext_sandbox_memory_get(
+        memory_idx, offset, buf_ptr, buf_length);
+  }
+  uint32_t ExtensionImpl::ext_sandbox_memory_new(uint32_t initial,
+                                                 uint32_t maximum) {
+    return sandboxing_ext_.ext_sandbox_memory_new(initial, maximum);
+  }
+  uint32_t ExtensionImpl::ext_sandbox_memory_set(uint32_t memory_idx,
+                                                 uint32_t offset,
+                                                 const uint8_t *val_ptr,
+                                                 uint32_t val_len) {
+    return sandboxing_ext_.ext_sandbox_memory_set(
+        memory_idx, offset, val_ptr, val_len);
+  }
+  void ExtensionImpl::ext_sandbox_memory_teardown(uint32_t memory_idx) {
+    sandboxing_ext_.ext_sandbox_memory_teardown(memory_idx);
+  }
+
+  /// misc extensions
+  uint64_t ExtensionImpl::ext_chain_id() {
+    return misc_ext_.ext_chain_id();
+  }
+}  // namespace extensions

--- a/core/extensions/extension_impl.cpp
+++ b/core/extensions/extension_impl.cpp
@@ -8,109 +8,104 @@
 namespace extensions {
   /// storage extensions
   uint8_t *ExtensionImpl::ext_child_storage_root(
-      const uint8_t *storage_key_data,
-      uint32_t storage_key_length,
+      const uint8_t *storage_key_data, uint32_t storage_key_length,
       uint32_t *written) {
-    return storage_ext_.ext_child_storage_root(
-        storage_key_data, storage_key_length, written);
+    return storage_ext_.ext_child_storage_root(storage_key_data,
+                                               storage_key_length, written);
   }
+
   void ExtensionImpl::ext_clear_child_storage(const uint8_t *storage_key_data,
                                               uint32_t storage_key_length,
                                               const uint8_t *key_data,
                                               uint32_t key_length) {
-    storage_ext_.ext_clear_child_storage(
-        storage_key_data, storage_key_length, key_data, key_length);
+    storage_ext_.ext_clear_child_storage(storage_key_data, storage_key_length,
+                                         key_data, key_length);
   }
+
   void ExtensionImpl::ext_clear_prefix(const uint8_t *prefix_data,
                                        uint32_t prefix_length) {
     storage_ext_.ext_clear_prefix(prefix_data, prefix_length);
   }
+
   void ExtensionImpl::ext_clear_storage(const uint8_t *key_data,
                                         uint32_t key_length) {
     storage_ext_.ext_clear_storage(key_data, key_length);
   }
+
   uint32_t ExtensionImpl::ext_exists_child_storage(
-      const uint8_t *storage_key_data,
-      uint32_t storage_key_length,
-      const uint8_t *key_data,
-      uint32_t key_length) {
+      const uint8_t *storage_key_data, uint32_t storage_key_length,
+      const uint8_t *key_data, uint32_t key_length) {
     return storage_ext_.ext_exists_child_storage(
         storage_key_data, storage_key_length, key_data, key_length);
   }
+
   uint8_t *ExtensionImpl::ext_get_allocated_child_storage(
-      const uint8_t *storage_key_data,
-      uint32_t storage_key_length,
-      const uint8_t *key_data,
-      uint32_t key_length,
-      uint32_t *written) {
+      const uint8_t *storage_key_data, uint32_t storage_key_length,
+      const uint8_t *key_data, uint32_t key_length, uint32_t *written) {
     return storage_ext_.ext_get_allocated_child_storage(
         storage_key_data, storage_key_length, key_data, key_length, written);
   }
+
   uint8_t *ExtensionImpl::ext_get_allocated_storage(const uint8_t *key_data,
                                                     uint32_t key_length,
                                                     uint32_t *written) {
-    return storage_ext_.ext_get_allocated_storage(
-        key_data, key_length, written);
+    return storage_ext_.ext_get_allocated_storage(key_data, key_length,
+                                                  written);
   }
+
   uint32_t ExtensionImpl::ext_get_child_storage_into(
-      const uint8_t *storage_key_data,
-      uint32_t storage_key_length,
-      const uint8_t *key_data,
-      uint32_t key_length,
-      uint8_t *value_data,
-      uint32_t value_length,
-      uint32_t value_offset) {
-    return storage_ext_.ext_get_child_storage_into(storage_key_data,
-                                                   storage_key_length,
-                                                   key_data,
-                                                   key_length,
-                                                   value_data,
-                                                   value_length,
-                                                   value_offset);
+      const uint8_t *storage_key_data, uint32_t storage_key_length,
+      const uint8_t *key_data, uint32_t key_length, uint8_t *value_data,
+      uint32_t value_length, uint32_t value_offset) {
+    return storage_ext_.ext_get_child_storage_into(
+        storage_key_data, storage_key_length, key_data, key_length, value_data,
+        value_length, value_offset);
   }
+
   uint32_t ExtensionImpl::ext_get_storage_into(const uint8_t *key_data,
                                                uint32_t key_length,
                                                uint8_t *value_data,
                                                uint32_t value_length,
                                                uint32_t value_offset) {
-    return storage_ext_.ext_get_storage_into(
-        key_data, key_length, value_data, value_length, value_offset);
+    return storage_ext_.ext_get_storage_into(key_data, key_length, value_data,
+                                             value_length, value_offset);
   }
+
   void ExtensionImpl::ext_kill_child_storage(const uint8_t *storage_key_data,
                                              uint32_t storage_key_length) {
     storage_ext_.ext_kill_child_storage(storage_key_data, storage_key_length);
   }
+
   void ExtensionImpl::ext_set_child_storage(const uint8_t *storage_key_data,
                                             uint32_t storage_key_length,
                                             const uint8_t *key_data,
                                             uint32_t key_length,
                                             const uint8_t *value_data,
                                             uint32_t value_length) {
-    storage_ext_.ext_set_child_storage(storage_key_data,
-                                       storage_key_length,
-                                       key_data,
-                                       key_length,
-                                       value_data,
+    storage_ext_.ext_set_child_storage(storage_key_data, storage_key_length,
+                                       key_data, key_length, value_data,
                                        value_length);
   }
+
   void ExtensionImpl::ext_set_storage(const uint8_t *key_data,
                                       uint32_t key_length,
                                       const uint8_t *value_data,
                                       uint32_t value_length) {
-    storage_ext_.ext_set_storage(
-        key_data, key_length, value_data, value_length);
+    storage_ext_.ext_set_storage(key_data, key_length, value_data,
+                                 value_length);
   }
+
   uint32_t ExtensionImpl::ext_storage_changes_root(
-      const uint8_t *parent_hash_data,
-      uint32_t parent_hash_len,
-      uint64_t parent_num,
-      uint8_t *result) {
+      const uint8_t *parent_hash_data, uint32_t parent_hash_len,
+      uint64_t parent_num, uint8_t *result) {
     return storage_ext_.ext_storage_changes_root(
         parent_hash_data, parent_hash_len, parent_num, result);
   }
+
   void ExtensionImpl::ext_storage_root(uint8_t *result) {
     storage_ext_.ext_storage_root(result);
   }
+
   uint32_t ExtensionImpl::ext_exists_storage(const uint8_t *key_data,
                                              uint32_t key_length) {
     return storage_ext_.ext_exists_storage(key_data, key_length);
@@ -120,6 +115,7 @@ namespace extensions {
   uint8_t *ExtensionImpl::ext_malloc(uint32_t size) {
     return memory_ext_.ext_malloc(size);
   }
+
   void ExtensionImpl::ext_free(uint8_t *ptr) {
     memory_ext_.ext_free(ptr);
   }
@@ -128,42 +124,43 @@ namespace extensions {
   void ExtensionImpl::ext_print_hex(const uint8_t *data, uint32_t length) {
     io_ext_.ext_print_hex(data, length);
   }
+
   void ExtensionImpl::ext_print_num(uint64_t value) {
     io_ext_.ext_print_num(value);
   }
+
   void ExtensionImpl::ext_print_utf8(const uint8_t *utf8_data,
                                      uint32_t utf8_length) {
     io_ext_.ext_print_utf8(utf8_data, utf8_length);
   }
 
   /// cryptographic extensions
-  void ExtensionImpl::ext_blake2_256(const uint8_t *data,
-                                     uint32_t len,
+  void ExtensionImpl::ext_blake2_256(const uint8_t *data, uint32_t len,
                                      uint8_t *out) {
     crypto_ext_.ext_blake2_256(data, len, out);
   }
+
   void ExtensionImpl::ext_blake2_256_enumerated_trie_root(
-      const uint8_t *values_data,
-      const uint32_t *lens_data,
-      uint32_t lens_length,
-      uint8_t *result) {
-    crypto_ext_.ext_blake2_256_enumerated_trie_root(
-        values_data, lens_data, lens_length, result);
+      const uint8_t *values_data, const uint32_t *lens_data,
+      uint32_t lens_length, uint8_t *result) {
+    crypto_ext_.ext_blake2_256_enumerated_trie_root(values_data, lens_data,
+                                                    lens_length, result);
   }
+
   uint32_t ExtensionImpl::ext_ed25519_verify(const uint8_t *msg_data,
                                              uint32_t msg_len,
                                              const uint8_t *sig_data,
                                              const uint8_t *pubkey_data) {
-    return crypto_ext_.ext_ed25519_verify(
-        msg_data, msg_len, sig_data, pubkey_data);
+    return crypto_ext_.ext_ed25519_verify(msg_data, msg_len, sig_data,
+                                          pubkey_data);
   }
-  void ExtensionImpl::ext_twox_128(const uint8_t *data,
-                                   uint32_t len,
+
+  void ExtensionImpl::ext_twox_128(const uint8_t *data, uint32_t len,
                                    uint8_t *out) {
     crypto_ext_.ext_twox_128(data, len, out);
   }
-  void ExtensionImpl::ext_twox_256(const uint8_t *data,
-                                   uint32_t len,
+
+  void ExtensionImpl::ext_twox_256(const uint8_t *data, uint32_t len,
                                    uint8_t *out) {
     crypto_ext_.ext_twox_256(data, len, out);
   }
@@ -172,58 +169,46 @@ namespace extensions {
   void ExtensionImpl::ext_sandbox_instance_teardown(uint32_t instance_idx) {
     sandboxing_ext_.ext_sandbox_instance_teardown(instance_idx);
   }
+
   uint32_t ExtensionImpl::ext_sandbox_instantiate(
-      std::function<uint64_t(const uint8_t *serialized_args,
-                             size_t serialized_args_length,
-                             size_t state,
-                             size_t func_index)> dispatch_func,
-      const uint8_t *wasm_ptr,
-      size_t wasm_length,
-      const uint8_t *imports_ptr,
-      size_t imports_length,
+      SandoxDispatchFuncType dispatch_func, const uint8_t *wasm_ptr,
+      size_t wasm_length, const uint8_t *imports_ptr, size_t imports_length,
       size_t state) {
-    return sandboxing_ext_.ext_sandbox_instantiate(dispatch_func,
-                                                   wasm_ptr,
-                                                   wasm_length,
-                                                   imports_ptr,
-                                                   imports_length,
-                                                   state);
+    return sandboxing_ext_.ext_sandbox_instantiate(dispatch_func, wasm_ptr,
+                                                   wasm_length, imports_ptr,
+                                                   imports_length, state);
   }
-  uint32_t ExtensionImpl::ext_sandbox_invoke(uint32_t instance_idx,
-                                             const uint8_t *export_ptr,
-                                             size_t export_len,
-                                             const uint8_t *args_ptr,
-                                             size_t args_len,
-                                             uint8_t *return_val_ptr,
-                                             size_t return_val_len,
-                                             size_t state) {
-    return sandboxing_ext_.ext_sandbox_invoke(instance_idx,
-                                              export_ptr,
-                                              export_len,
-                                              args_ptr,
-                                              args_len,
-                                              return_val_ptr,
-                                              return_val_len,
-                                              state);
+
+  uint32_t ExtensionImpl::ext_sandbox_invoke(
+      uint32_t instance_idx, const uint8_t *export_ptr, size_t export_len,
+      const uint8_t *args_ptr, size_t args_len, uint8_t *return_val_ptr,
+      size_t return_val_len, size_t state) {
+    return sandboxing_ext_.ext_sandbox_invoke(
+        instance_idx, export_ptr, export_len, args_ptr, args_len,
+        return_val_ptr, return_val_len, state);
   }
+
   uint32_t ExtensionImpl::ext_sandbox_memory_get(uint32_t memory_idx,
                                                  uint32_t offset,
                                                  uint8_t *buf_ptr,
                                                  size_t buf_length) {
-    return sandboxing_ext_.ext_sandbox_memory_get(
-        memory_idx, offset, buf_ptr, buf_length);
+    return sandboxing_ext_.ext_sandbox_memory_get(memory_idx, offset, buf_ptr,
+                                                  buf_length);
   }
+
   uint32_t ExtensionImpl::ext_sandbox_memory_new(uint32_t initial,
                                                  uint32_t maximum) {
     return sandboxing_ext_.ext_sandbox_memory_new(initial, maximum);
   }
+
   uint32_t ExtensionImpl::ext_sandbox_memory_set(uint32_t memory_idx,
                                                  uint32_t offset,
                                                  const uint8_t *val_ptr,
                                                  size_t val_len) {
-    return sandboxing_ext_.ext_sandbox_memory_set(
-        memory_idx, offset, val_ptr, val_len);
+    return sandboxing_ext_.ext_sandbox_memory_set(memory_idx, offset, val_ptr,
+                                                  val_len);
   }
+
   void ExtensionImpl::ext_sandbox_memory_teardown(uint32_t memory_idx) {
     sandboxing_ext_.ext_sandbox_memory_teardown(memory_idx);
   }
@@ -232,4 +217,6 @@ namespace extensions {
   uint64_t ExtensionImpl::ext_chain_id() {
     return misc_ext_.ext_chain_id();
   }
+
 }  // namespace extensions
+   // namespace extensions

--- a/core/extensions/extension_impl.cpp
+++ b/core/extensions/extension_impl.cpp
@@ -174,14 +174,14 @@ namespace extensions {
   }
   uint32_t ExtensionImpl::ext_sandbox_instantiate(
       std::function<uint64_t(const uint8_t *serialized_args,
-                             uint32_t serialized_args_length,
-                             uint32_t state,
-                             uint32_t func_index)> dispatch_func,
+                             size_t serialized_args_length,
+                             size_t state,
+                             size_t func_index)> dispatch_func,
       const uint8_t *wasm_ptr,
-      uint32_t wasm_length,
+      size_t wasm_length,
       const uint8_t *imports_ptr,
-      uint32_t imports_length,
-      uint32_t state) {
+      size_t imports_length,
+      size_t state) {
     return sandboxing_ext_.ext_sandbox_instantiate(dispatch_func,
                                                    wasm_ptr,
                                                    wasm_length,
@@ -191,12 +191,12 @@ namespace extensions {
   }
   uint32_t ExtensionImpl::ext_sandbox_invoke(uint32_t instance_idx,
                                              const uint8_t *export_ptr,
-                                             uint32_t export_len,
+                                             size_t export_len,
                                              const uint8_t *args_ptr,
-                                             uint32_t args_len,
+                                             size_t args_len,
                                              uint8_t *return_val_ptr,
-                                             uint32_t return_val_len,
-                                             uint32_t state) {
+                                             size_t return_val_len,
+                                             size_t state) {
     return sandboxing_ext_.ext_sandbox_invoke(instance_idx,
                                               export_ptr,
                                               export_len,
@@ -209,7 +209,7 @@ namespace extensions {
   uint32_t ExtensionImpl::ext_sandbox_memory_get(uint32_t memory_idx,
                                                  uint32_t offset,
                                                  uint8_t *buf_ptr,
-                                                 uint32_t buf_length) {
+                                                 size_t buf_length) {
     return sandboxing_ext_.ext_sandbox_memory_get(
         memory_idx, offset, buf_ptr, buf_length);
   }
@@ -220,7 +220,7 @@ namespace extensions {
   uint32_t ExtensionImpl::ext_sandbox_memory_set(uint32_t memory_idx,
                                                  uint32_t offset,
                                                  const uint8_t *val_ptr,
-                                                 uint32_t val_len) {
+                                                 size_t val_len) {
     return sandboxing_ext_.ext_sandbox_memory_set(
         memory_idx, offset, val_ptr, val_len);
   }

--- a/core/extensions/extension_impl.hpp
+++ b/core/extensions/extension_impl.hpp
@@ -105,32 +105,32 @@ namespace extensions {
     void ext_sandbox_instance_teardown(uint32_t instance_idx) override;
     uint32_t ext_sandbox_instantiate(
         std::function<uint64_t(const uint8_t *serialized_args,
-                               uint32_t serialized_args_length,
-                               uint32_t state,
-                               uint32_t func_index)> dispatch_func,
+                               size_t serialized_args_length,
+                               size_t state,
+                               size_t func_index)> dispatch_func,
         const uint8_t *wasm_ptr,
-        uint32_t wasm_length,
+        size_t wasm_length,
         const uint8_t *imports_ptr,
-        uint32_t imports_length,
-        uint32_t state) override;
+        size_t imports_length,
+        size_t state) override;
     uint32_t ext_sandbox_invoke(uint32_t instance_idx,
                                 const uint8_t *export_ptr,
-                                uint32_t export_len,
+                                size_t export_len,
                                 const uint8_t *args_ptr,
-                                uint32_t args_len,
+                                size_t args_len,
                                 uint8_t *return_val_ptr,
-                                uint32_t return_val_len,
-                                uint32_t state) override;
+                                size_t return_val_len,
+                                size_t state) override;
     uint32_t ext_sandbox_memory_get(uint32_t memory_idx,
                                     uint32_t offset,
                                     uint8_t *buf_ptr,
-                                    uint32_t buf_length) override;
+                                    size_t buf_length) override;
     uint32_t ext_sandbox_memory_new(uint32_t initial,
                                     uint32_t maximum) override;
     uint32_t ext_sandbox_memory_set(uint32_t memory_idx,
                                     uint32_t offset,
                                     const uint8_t *val_ptr,
-                                    uint32_t val_len) override;
+                                    size_t val_len) override;
     void ext_sandbox_memory_teardown(uint32_t memory_idx) override;
 
     /// misc extensions

--- a/core/extensions/extension_impl.hpp
+++ b/core/extensions/extension_impl.hpp
@@ -14,7 +14,7 @@
 #include "extensions/impl/sandboxing_extension.hpp"
 #include "extensions/impl/storage_extension.hpp"
 
-namespace extensions {
+namespace kagome::extensions {
   /**
    * Fair implementation of the extensions interface
    */
@@ -116,12 +116,10 @@ namespace extensions {
     /// sandboxing extensions
     void ext_sandbox_instance_teardown(uint32_t instance_idx) override;
 
-    uint32_t ext_sandbox_instantiate(SandoxDispatchFuncType dispatch_func,
-                                     const uint8_t *wasm_ptr,
-                                     size_t wasm_length,
-                                     const uint8_t *imports_ptr,
-                                     size_t imports_length,
-                                     size_t state) override;
+    uint32_t ext_sandbox_instantiate(
+        const SandoxDispatchFuncType &dispatch_func, const uint8_t *wasm_ptr,
+        size_t wasm_length, const uint8_t *imports_ptr, size_t imports_length,
+        size_t state) override;
 
     uint32_t ext_sandbox_invoke(uint32_t instance_idx,
                                 const uint8_t *export_ptr, size_t export_len,

--- a/core/extensions/extension_impl.hpp
+++ b/core/extensions/extension_impl.hpp
@@ -24,113 +24,122 @@ namespace extensions {
     uint8_t *ext_child_storage_root(const uint8_t *storage_key_data,
                                     uint32_t storage_key_length,
                                     uint32_t *written) override;
+
     void ext_clear_child_storage(const uint8_t *storage_key_data,
                                  uint32_t storage_key_length,
                                  const uint8_t *key_data,
                                  uint32_t key_length) override;
+
     void ext_clear_prefix(const uint8_t *prefix_data,
                           uint32_t prefix_length) override;
+
     void ext_clear_storage(const uint8_t *key_data,
                            uint32_t key_length) override;
+
     uint32_t ext_exists_child_storage(const uint8_t *storage_key_data,
                                       uint32_t storage_key_length,
                                       const uint8_t *key_data,
                                       uint32_t key_length) override;
+
     uint8_t *ext_get_allocated_child_storage(const uint8_t *storage_key_data,
                                              uint32_t storage_key_length,
                                              const uint8_t *key_data,
                                              uint32_t key_length,
                                              uint32_t *written) override;
+
     uint8_t *ext_get_allocated_storage(const uint8_t *key_data,
                                        uint32_t key_length,
                                        uint32_t *written) override;
-    uint32_t ext_get_child_storage_into(const uint8_t *storage_key_data,
-                                        uint32_t storage_key_length,
-                                        const uint8_t *key_data,
-                                        uint32_t key_length,
-                                        uint8_t *value_data,
-                                        uint32_t value_length,
-                                        uint32_t value_offset) override;
-    uint32_t ext_get_storage_into(const uint8_t *key_data,
-                                  uint32_t key_length,
-                                  uint8_t *value_data,
-                                  uint32_t value_length,
+
+    uint32_t ext_get_child_storage_into(
+        const uint8_t *storage_key_data, uint32_t storage_key_length,
+        const uint8_t *key_data, uint32_t key_length, uint8_t *value_data,
+        uint32_t value_length, uint32_t value_offset) override;
+
+    uint32_t ext_get_storage_into(const uint8_t *key_data, uint32_t key_length,
+                                  uint8_t *value_data, uint32_t value_length,
                                   uint32_t value_offset) override;
+
     void ext_kill_child_storage(const uint8_t *storage_key_data,
                                 uint32_t storage_key_length) override;
+
     void ext_set_child_storage(const uint8_t *storage_key_data,
                                uint32_t storage_key_length,
-                               const uint8_t *key_data,
-                               uint32_t key_length,
+                               const uint8_t *key_data, uint32_t key_length,
                                const uint8_t *value_data,
                                uint32_t value_length) override;
-    void ext_set_storage(const uint8_t *key_data,
-                         uint32_t key_length,
+
+    void ext_set_storage(const uint8_t *key_data, uint32_t key_length,
                          const uint8_t *value_data,
                          uint32_t value_length) override;
+
     uint32_t ext_storage_changes_root(const uint8_t *parent_hash_data,
                                       uint32_t parent_hash_len,
                                       uint64_t parent_num,
                                       uint8_t *result) override;
+
     void ext_storage_root(uint8_t *result) override;
+
     uint32_t ext_exists_storage(const uint8_t *key_data,
                                 uint32_t key_length) override;
 
     /// memory extensions
     uint8_t *ext_malloc(uint32_t size) override;
+
     void ext_free(uint8_t *ptr) override;
 
     /// I/O extensions
     void ext_print_hex(const uint8_t *data, uint32_t length) override;
+
     void ext_print_num(uint64_t value) override;
+
     void ext_print_utf8(const uint8_t *utf8_data,
                         uint32_t utf8_length) override;
 
     /// cryptographic extensions
-    void ext_blake2_256(const uint8_t *data,
-                        uint32_t len,
+    void ext_blake2_256(const uint8_t *data, uint32_t len,
                         uint8_t *out) override;
+
     void ext_blake2_256_enumerated_trie_root(const uint8_t *values_data,
                                              const uint32_t *lens_data,
                                              uint32_t lens_length,
                                              uint8_t *result) override;
-    uint32_t ext_ed25519_verify(const uint8_t *msg_data,
-                                uint32_t msg_len,
+
+    uint32_t ext_ed25519_verify(const uint8_t *msg_data, uint32_t msg_len,
                                 const uint8_t *sig_data,
                                 const uint8_t *pubkey_data) override;
+
     void ext_twox_128(const uint8_t *data, uint32_t len, uint8_t *out) override;
+
     void ext_twox_256(const uint8_t *data, uint32_t len, uint8_t *out) override;
 
     /// sandboxing extensions
     void ext_sandbox_instance_teardown(uint32_t instance_idx) override;
-    uint32_t ext_sandbox_instantiate(
-        std::function<uint64_t(const uint8_t *serialized_args,
-                               size_t serialized_args_length,
-                               size_t state,
-                               size_t func_index)> dispatch_func,
-        const uint8_t *wasm_ptr,
-        size_t wasm_length,
-        const uint8_t *imports_ptr,
-        size_t imports_length,
-        size_t state) override;
+
+    uint32_t ext_sandbox_instantiate(SandoxDispatchFuncType dispatch_func,
+                                     const uint8_t *wasm_ptr,
+                                     size_t wasm_length,
+                                     const uint8_t *imports_ptr,
+                                     size_t imports_length,
+                                     size_t state) override;
+
     uint32_t ext_sandbox_invoke(uint32_t instance_idx,
-                                const uint8_t *export_ptr,
-                                size_t export_len,
-                                const uint8_t *args_ptr,
-                                size_t args_len,
-                                uint8_t *return_val_ptr,
-                                size_t return_val_len,
+                                const uint8_t *export_ptr, size_t export_len,
+                                const uint8_t *args_ptr, size_t args_len,
+                                uint8_t *return_val_ptr, size_t return_val_len,
                                 size_t state) override;
-    uint32_t ext_sandbox_memory_get(uint32_t memory_idx,
-                                    uint32_t offset,
+
+    uint32_t ext_sandbox_memory_get(uint32_t memory_idx, uint32_t offset,
                                     uint8_t *buf_ptr,
                                     size_t buf_length) override;
+
     uint32_t ext_sandbox_memory_new(uint32_t initial,
                                     uint32_t maximum) override;
-    uint32_t ext_sandbox_memory_set(uint32_t memory_idx,
-                                    uint32_t offset,
+
+    uint32_t ext_sandbox_memory_set(uint32_t memory_idx, uint32_t offset,
                                     const uint8_t *val_ptr,
                                     size_t val_len) override;
+
     void ext_sandbox_memory_teardown(uint32_t memory_idx) override;
 
     /// misc extensions

--- a/core/extensions/extension_impl.hpp
+++ b/core/extensions/extension_impl.hpp
@@ -62,11 +62,11 @@ namespace extensions {
                                uint32_t storage_key_length,
                                const uint8_t *key_data,
                                uint32_t key_length,
-                               uint8_t *value_data,
+                               const uint8_t *value_data,
                                uint32_t value_length) override;
     void ext_set_storage(const uint8_t *key_data,
                          uint32_t key_length,
-                         uint8_t *value_data,
+                         const uint8_t *value_data,
                          uint32_t value_length) override;
     uint32_t ext_storage_changes_root(const uint8_t *parent_hash_data,
                                       uint32_t parent_hash_len,

--- a/core/extensions/extension_impl.hpp
+++ b/core/extensions/extension_impl.hpp
@@ -1,0 +1,149 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_EXTENSION_IMPL_HPP
+#define KAGOME_EXTENSION_IMPL_HPP
+
+#include "extensions/extension.hpp"
+#include "extensions/impl/crypto_extension.hpp"
+#include "extensions/impl/io_extension.hpp"
+#include "extensions/impl/memory_extension.hpp"
+#include "extensions/impl/misc_extension.hpp"
+#include "extensions/impl/sandboxing_extension.hpp"
+#include "extensions/impl/storage_extension.hpp"
+
+namespace extensions {
+  /**
+   * Fair implementation of the extensions interface
+   */
+  class ExtensionImpl : public Extension {
+   public:
+    /// storage extensions
+    uint8_t *ext_child_storage_root(const uint8_t *storage_key_data,
+                                    uint32_t storage_key_length,
+                                    uint32_t *written) override;
+    void ext_clear_child_storage(const uint8_t *storage_key_data,
+                                 uint32_t storage_key_length,
+                                 const uint8_t *key_data,
+                                 uint32_t key_length) override;
+    void ext_clear_prefix(const uint8_t *prefix_data,
+                          uint32_t prefix_length) override;
+    void ext_clear_storage(const uint8_t *key_data,
+                           uint32_t key_length) override;
+    uint32_t ext_exists_child_storage(const uint8_t *storage_key_data,
+                                      uint32_t storage_key_length,
+                                      const uint8_t *key_data,
+                                      uint32_t key_length) override;
+    uint8_t *ext_get_allocated_child_storage(const uint8_t *storage_key_data,
+                                             uint32_t storage_key_length,
+                                             const uint8_t *key_data,
+                                             uint32_t key_length,
+                                             uint32_t *written) override;
+    uint8_t *ext_get_allocated_storage(const uint8_t *key_data,
+                                       uint32_t key_length,
+                                       uint32_t *written) override;
+    uint32_t ext_get_child_storage_into(const uint8_t *storage_key_data,
+                                        uint32_t storage_key_length,
+                                        const uint8_t *key_data,
+                                        uint32_t key_length,
+                                        uint8_t *value_data,
+                                        uint32_t value_length,
+                                        uint32_t value_offset) override;
+    uint32_t ext_get_storage_into(const uint8_t *key_data,
+                                  uint32_t key_length,
+                                  uint8_t *value_data,
+                                  uint32_t value_length,
+                                  uint32_t value_offset) override;
+    void ext_kill_child_storage(const uint8_t *storage_key_data,
+                                uint32_t storage_key_length) override;
+    void ext_set_child_storage(const uint8_t *storage_key_data,
+                               uint32_t storage_key_length,
+                               const uint8_t *key_data,
+                               uint32_t key_length,
+                               uint8_t *value_data,
+                               uint32_t value_length) override;
+    void ext_set_storage(const uint8_t *key_data,
+                         uint32_t key_length,
+                         uint8_t *value_data,
+                         uint32_t value_length) override;
+    uint32_t ext_storage_changes_root(const uint8_t *parent_hash_data,
+                                      uint32_t parent_hash_len,
+                                      uint64_t parent_num,
+                                      uint8_t *result) override;
+    void ext_storage_root(uint8_t *result) override;
+    uint32_t ext_exists_storage(const uint8_t *key_data,
+                                uint32_t key_length) override;
+
+    /// memory extensions
+    uint8_t *ext_malloc(uint32_t size) override;
+    void ext_free(uint8_t *ptr) override;
+
+    /// I/O extensions
+    void ext_print_hex(const uint8_t *data, uint32_t length) override;
+    void ext_print_num(uint64_t value) override;
+    void ext_print_utf8(const uint8_t *utf8_data,
+                        uint32_t utf8_length) override;
+
+    /// cryptographic extensions
+    void ext_blake2_256(const uint8_t *data,
+                        uint32_t len,
+                        uint8_t *out) override;
+    void ext_blake2_256_enumerated_trie_root(const uint8_t *values_data,
+                                             const uint32_t *lens_data,
+                                             uint32_t lens_length,
+                                             uint8_t *result) override;
+    uint32_t ext_ed25519_verify(const uint8_t *msg_data,
+                                uint32_t msg_len,
+                                const uint8_t *sig_data,
+                                const uint8_t *pubkey_data) override;
+    void ext_twox_128(const uint8_t *data, uint32_t len, uint8_t *out) override;
+    void ext_twox_256(const uint8_t *data, uint32_t len, uint8_t *out) override;
+
+    /// sandboxing extensions
+    void ext_sandbox_instance_teardown(uint32_t instance_idx) override;
+    uint32_t ext_sandbox_instantiate(
+        std::function<uint64_t(const uint8_t *serialized_args,
+                               uint32_t serialized_args_length,
+                               uint32_t state,
+                               uint32_t func_index)> dispatch_func,
+        const uint8_t *wasm_ptr,
+        uint32_t wasm_length,
+        const uint8_t *imports_ptr,
+        uint32_t imports_length,
+        uint32_t state) override;
+    uint32_t ext_sandbox_invoke(uint32_t instance_idx,
+                                const uint8_t *export_ptr,
+                                uint32_t export_len,
+                                const uint8_t *args_ptr,
+                                uint32_t args_len,
+                                uint8_t *return_val_ptr,
+                                uint32_t return_val_len,
+                                uint32_t state) override;
+    uint32_t ext_sandbox_memory_get(uint32_t memory_idx,
+                                    uint32_t offset,
+                                    uint8_t *buf_ptr,
+                                    uint32_t buf_length) override;
+    uint32_t ext_sandbox_memory_new(uint32_t initial,
+                                    uint32_t maximum) override;
+    uint32_t ext_sandbox_memory_set(uint32_t memory_idx,
+                                    uint32_t offset,
+                                    const uint8_t *val_ptr,
+                                    uint32_t val_len) override;
+    void ext_sandbox_memory_teardown(uint32_t memory_idx) override;
+
+    /// misc extensions
+    uint64_t ext_chain_id() override;
+
+   private:
+    CryptoExtension crypto_ext_;
+    IOExtension io_ext_;
+    MemoryExtension memory_ext_;
+    MiscExtension misc_ext_;
+    SandboxingExtension sandboxing_ext_;
+    StorageExtension storage_ext_;
+  };
+}  // namespace extensions
+
+#endif  // KAGOME_EXTENSION_IMPL_HPP

--- a/core/extensions/impl/crypto_extension.cpp
+++ b/core/extensions/impl/crypto_extension.cpp
@@ -8,31 +8,30 @@
 #include "extensions/impl/crypto_extension.hpp"
 
 namespace extensions {
-  void CryptoExtension::ext_blake2_256(const uint8_t *data,
-                                       uint32_t len,
+  void CryptoExtension::ext_blake2_256(const uint8_t *data, uint32_t len,
                                        uint8_t *out) {
     std::terminate();
   }
+
   void CryptoExtension::ext_blake2_256_enumerated_trie_root(
-      const uint8_t *values_data,
-      const uint32_t *lens_data,
-      uint32_t lens_length,
-      uint8_t *result) {
+      const uint8_t *values_data, const uint32_t *lens_data,
+      uint32_t lens_length, uint8_t *result) {
     std::terminate();
   }
+
   uint32_t CryptoExtension::ext_ed25519_verify(const uint8_t *msg_data,
                                                uint32_t msg_len,
                                                const uint8_t *sig_data,
                                                const uint8_t *pubkey_data) {
     std::terminate();
   }
-  void CryptoExtension::ext_twox_128(const uint8_t *data,
-                                     uint32_t len,
+
+  void CryptoExtension::ext_twox_128(const uint8_t *data, uint32_t len,
                                      uint8_t *out) {
     std::terminate();
   }
-  void CryptoExtension::ext_twox_256(const uint8_t *data,
-                                     uint32_t len,
+
+  void CryptoExtension::ext_twox_256(const uint8_t *data, uint32_t len,
                                      uint8_t *out) {
     std::terminate();
   }

--- a/core/extensions/impl/crypto_extension.cpp
+++ b/core/extensions/impl/crypto_extension.cpp
@@ -1,0 +1,39 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <exception>
+
+#include "extensions/impl/crypto_extension.hpp"
+
+namespace extensions {
+  void CryptoExtension::ext_blake2_256(const uint8_t *data,
+                                       uint32_t len,
+                                       uint8_t *out) {
+    std::terminate();
+  }
+  void CryptoExtension::ext_blake2_256_enumerated_trie_root(
+      const uint8_t *values_data,
+      const uint32_t *lens_data,
+      uint32_t lens_length,
+      uint8_t *result) {
+    std::terminate();
+  }
+  uint32_t CryptoExtension::ext_ed25519_verify(const uint8_t *msg_data,
+                                               uint32_t msg_len,
+                                               const uint8_t *sig_data,
+                                               const uint8_t *pubkey_data) {
+    std::terminate();
+  }
+  void CryptoExtension::ext_twox_128(const uint8_t *data,
+                                     uint32_t len,
+                                     uint8_t *out) {
+    std::terminate();
+  }
+  void CryptoExtension::ext_twox_256(const uint8_t *data,
+                                     uint32_t len,
+                                     uint8_t *out) {
+    std::terminate();
+  }
+}  // namespace extensions

--- a/core/extensions/impl/crypto_extension.cpp
+++ b/core/extensions/impl/crypto_extension.cpp
@@ -7,7 +7,7 @@
 
 #include "extensions/impl/crypto_extension.hpp"
 
-namespace extensions {
+namespace kagome::extensions {
   void CryptoExtension::ext_blake2_256(const uint8_t *data, uint32_t len,
                                        uint8_t *out) {
     std::terminate();

--- a/core/extensions/impl/crypto_extension.hpp
+++ b/core/extensions/impl/crypto_extension.hpp
@@ -6,33 +6,25 @@
 #ifndef KAGOME_CRYPTO_EXTENSION_HPP
 #define KAGOME_CRYPTO_EXTENSION_HPP
 
+#include <cstdint>
+
 namespace extensions {
   /**
    * Implements extension functions related to cryptography
    */
   class CryptoExtension {
    public:
-    void ext_blake2_256(const uint8_t *data, uint32_t len, uint8_t *out) {
-      std::terminate();
-    }
+    void ext_blake2_256(const uint8_t *data, uint32_t len, uint8_t *out);
     void ext_blake2_256_enumerated_trie_root(const uint8_t *values_data,
                                              const uint32_t *lens_data,
                                              uint32_t lens_length,
-                                             uint8_t *result) {
-      std::terminate();
-    }
+                                             uint8_t *result);
     uint32_t ext_ed25519_verify(const uint8_t *msg_data,
                                 uint32_t msg_len,
                                 const uint8_t *sig_data,
-                                const uint8_t *pubkey_data) {
-      std::terminate();
-    }
-    void ext_twox_128(const uint8_t *data, uint32_t len, uint8_t *out) {
-      std::terminate();
-    }
-    void ext_twox_256(const uint8_t *data, uint32_t len, uint8_t *out) {
-      std::terminate();
-    }
+                                const uint8_t *pubkey_data);
+    void ext_twox_128(const uint8_t *data, uint32_t len, uint8_t *out);
+    void ext_twox_256(const uint8_t *data, uint32_t len, uint8_t *out);
   };
 }  // namespace extensions
 

--- a/core/extensions/impl/crypto_extension.hpp
+++ b/core/extensions/impl/crypto_extension.hpp
@@ -1,0 +1,39 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_CRYPTO_EXTENSION_HPP
+#define KAGOME_CRYPTO_EXTENSION_HPP
+
+namespace extensions {
+  /**
+   * Implements extension functions related to cryptography
+   */
+  class CryptoExtension {
+   public:
+    void ext_blake2_256(const uint8_t *data, uint32_t len, uint8_t *out) {
+      std::terminate();
+    }
+    void ext_blake2_256_enumerated_trie_root(const uint8_t *values_data,
+                                             const uint32_t *lens_data,
+                                             uint32_t lens_length,
+                                             uint8_t *result) {
+      std::terminate();
+    }
+    uint32_t ext_ed25519_verify(const uint8_t *msg_data,
+                                uint32_t msg_len,
+                                const uint8_t *sig_data,
+                                const uint8_t *pubkey_data) {
+      std::terminate();
+    }
+    void ext_twox_128(const uint8_t *data, uint32_t len, uint8_t *out) {
+      std::terminate();
+    }
+    void ext_twox_256(const uint8_t *data, uint32_t len, uint8_t *out) {
+      std::terminate();
+    }
+  };
+}  // namespace extensions
+
+#endif  // KAGOME_CRYPTO_EXTENSION_HPP

--- a/core/extensions/impl/crypto_extension.hpp
+++ b/core/extensions/impl/crypto_extension.hpp
@@ -15,15 +15,18 @@ namespace extensions {
   class CryptoExtension {
    public:
     void ext_blake2_256(const uint8_t *data, uint32_t len, uint8_t *out);
+
     void ext_blake2_256_enumerated_trie_root(const uint8_t *values_data,
                                              const uint32_t *lens_data,
                                              uint32_t lens_length,
                                              uint8_t *result);
-    uint32_t ext_ed25519_verify(const uint8_t *msg_data,
-                                uint32_t msg_len,
+
+    uint32_t ext_ed25519_verify(const uint8_t *msg_data, uint32_t msg_len,
                                 const uint8_t *sig_data,
                                 const uint8_t *pubkey_data);
+
     void ext_twox_128(const uint8_t *data, uint32_t len, uint8_t *out);
+
     void ext_twox_256(const uint8_t *data, uint32_t len, uint8_t *out);
   };
 }  // namespace extensions

--- a/core/extensions/impl/crypto_extension.hpp
+++ b/core/extensions/impl/crypto_extension.hpp
@@ -8,7 +8,7 @@
 
 #include <cstdint>
 
-namespace extensions {
+namespace kagome::extensions {
   /**
    * Implements extension functions related to cryptography
    */

--- a/core/extensions/impl/io_extension.cpp
+++ b/core/extensions/impl/io_extension.cpp
@@ -11,9 +11,11 @@ namespace extensions {
   void IOExtension::ext_print_hex(const uint8_t *data, uint32_t length) {
     std::terminate();
   }
+
   void IOExtension::ext_print_num(uint64_t value) {
     std::terminate();
   }
+
   void IOExtension::ext_print_utf8(const uint8_t *utf8_data,
                                    uint32_t utf8_length) {
     std::terminate();

--- a/core/extensions/impl/io_extension.cpp
+++ b/core/extensions/impl/io_extension.cpp
@@ -7,7 +7,7 @@
 
 #include "extensions/impl/io_extension.hpp"
 
-namespace extensions {
+namespace kagome::extensions {
   void IOExtension::ext_print_hex(const uint8_t *data, uint32_t length) {
     std::terminate();
   }

--- a/core/extensions/impl/io_extension.cpp
+++ b/core/extensions/impl/io_extension.cpp
@@ -1,0 +1,21 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <exception>
+
+#include "extensions/impl/io_extension.hpp"
+
+namespace extensions {
+  void IOExtension::ext_print_hex(const uint8_t *data, uint32_t length) {
+    std::terminate();
+  }
+  void IOExtension::ext_print_num(uint64_t value) {
+    std::terminate();
+  }
+  void IOExtension::ext_print_utf8(const uint8_t *utf8_data,
+                                   uint32_t utf8_length) {
+    std::terminate();
+  }
+}  // namespace extensions

--- a/core/extensions/impl/io_extension.hpp
+++ b/core/extensions/impl/io_extension.hpp
@@ -1,0 +1,27 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_IO_EXTENSION_HPP
+#define KAGOME_IO_EXTENSION_HPP
+
+namespace extensions {
+  /**
+   * Implements extension functions related to IO
+   */
+  class IOExtension {
+   public:
+    void ext_print_hex(const uint8_t *data, uint32_t length) {
+      std::terminate();
+    }
+    void ext_print_num(uint64_t value) {
+      std::terminate();
+    }
+    void ext_print_utf8(const uint8_t *utf8_data, uint32_t utf8_length) {
+      std::terminate();
+    }
+  };
+}  // namespace extensions
+
+#endif  // KAGOME_IO_EXTENSION_HPP

--- a/core/extensions/impl/io_extension.hpp
+++ b/core/extensions/impl/io_extension.hpp
@@ -15,7 +15,9 @@ namespace extensions {
   class IOExtension {
    public:
     void ext_print_hex(const uint8_t *data, uint32_t length);
+
     void ext_print_num(uint64_t value);
+
     void ext_print_utf8(const uint8_t *utf8_data, uint32_t utf8_length);
   };
 }  // namespace extensions

--- a/core/extensions/impl/io_extension.hpp
+++ b/core/extensions/impl/io_extension.hpp
@@ -6,21 +6,17 @@
 #ifndef KAGOME_IO_EXTENSION_HPP
 #define KAGOME_IO_EXTENSION_HPP
 
+#include <cstdint>
+
 namespace extensions {
   /**
    * Implements extension functions related to IO
    */
   class IOExtension {
    public:
-    void ext_print_hex(const uint8_t *data, uint32_t length) {
-      std::terminate();
-    }
-    void ext_print_num(uint64_t value) {
-      std::terminate();
-    }
-    void ext_print_utf8(const uint8_t *utf8_data, uint32_t utf8_length) {
-      std::terminate();
-    }
+    void ext_print_hex(const uint8_t *data, uint32_t length);
+    void ext_print_num(uint64_t value);
+    void ext_print_utf8(const uint8_t *utf8_data, uint32_t utf8_length);
   };
 }  // namespace extensions
 

--- a/core/extensions/impl/io_extension.hpp
+++ b/core/extensions/impl/io_extension.hpp
@@ -8,7 +8,7 @@
 
 #include <cstdint>
 
-namespace extensions {
+namespace kagome::extensions {
   /**
    * Implements extension functions related to IO
    */

--- a/core/extensions/impl/memory_extension.cpp
+++ b/core/extensions/impl/memory_extension.cpp
@@ -1,0 +1,17 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <exception>
+
+#include "extensions/impl/memory_extension.hpp"
+
+namespace extensions {
+  uint8_t *MemoryExtension::ext_malloc(uint32_t size) {
+    std::terminate();
+  }
+  void MemoryExtension::ext_free(uint8_t *ptr) {
+    std::terminate();
+  }
+}  // namespace extensions

--- a/core/extensions/impl/memory_extension.cpp
+++ b/core/extensions/impl/memory_extension.cpp
@@ -11,6 +11,7 @@ namespace extensions {
   uint8_t *MemoryExtension::ext_malloc(uint32_t size) {
     std::terminate();
   }
+
   void MemoryExtension::ext_free(uint8_t *ptr) {
     std::terminate();
   }

--- a/core/extensions/impl/memory_extension.cpp
+++ b/core/extensions/impl/memory_extension.cpp
@@ -7,7 +7,7 @@
 
 #include "extensions/impl/memory_extension.hpp"
 
-namespace extensions {
+namespace kagome::extensions {
   uint8_t *MemoryExtension::ext_malloc(uint32_t size) {
     std::terminate();
   }

--- a/core/extensions/impl/memory_extension.hpp
+++ b/core/extensions/impl/memory_extension.hpp
@@ -13,6 +13,7 @@ namespace extensions {
   class MemoryExtension {
    public:
     uint8_t *ext_malloc(uint32_t size);
+
     void ext_free(uint8_t *ptr);
   };
 }  // namespace extensions

--- a/core/extensions/impl/memory_extension.hpp
+++ b/core/extensions/impl/memory_extension.hpp
@@ -12,12 +12,8 @@ namespace extensions {
    */
   class MemoryExtension {
    public:
-    uint8_t *ext_malloc(uint32_t size) {
-      std::terminate();
-    }
-    void ext_free(uint8_t *ptr) {
-      std::terminate();
-    }
+    uint8_t *ext_malloc(uint32_t size);
+    void ext_free(uint8_t *ptr);
   };
 }  // namespace extensions
 

--- a/core/extensions/impl/memory_extension.hpp
+++ b/core/extensions/impl/memory_extension.hpp
@@ -8,7 +8,7 @@
 
 #include <cstdint>
 
-namespace extensions {
+namespace kagome::extensions {
   /**
    * Implements extension functions related to memory
    */

--- a/core/extensions/impl/memory_extension.hpp
+++ b/core/extensions/impl/memory_extension.hpp
@@ -1,0 +1,24 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_MEMORY_EXTENSIONS_HPP
+#define KAGOME_MEMORY_EXTENSIONS_HPP
+
+namespace extensions {
+  /**
+   * Implements extension functions related to memory
+   */
+  class MemoryExtension {
+   public:
+    uint8_t *ext_malloc(uint32_t size) {
+      std::terminate();
+    }
+    void ext_free(uint8_t *ptr) {
+      std::terminate();
+    }
+  };
+}  // namespace extensions
+
+#endif  // KAGOME_MEMORY_EXTENSIONS_HPP

--- a/core/extensions/impl/memory_extension.hpp
+++ b/core/extensions/impl/memory_extension.hpp
@@ -6,6 +6,8 @@
 #ifndef KAGOME_MEMORY_EXTENSIONS_HPP
 #define KAGOME_MEMORY_EXTENSIONS_HPP
 
+#include <cstdint>
+
 namespace extensions {
   /**
    * Implements extension functions related to memory

--- a/core/extensions/impl/misc_extension.cpp
+++ b/core/extensions/impl/misc_extension.cpp
@@ -7,7 +7,7 @@
 
 #include "extensions/impl/misc_extension.hpp"
 
-namespace extensions {
+namespace kagome::extensions {
   uint64_t MiscExtension::ext_chain_id() {
     std::terminate();
   }

--- a/core/extensions/impl/misc_extension.cpp
+++ b/core/extensions/impl/misc_extension.cpp
@@ -1,0 +1,14 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <exception>
+
+#include "extensions/impl/misc_extension.hpp"
+
+namespace extensions {
+  uint64_t MiscExtension::ext_chain_id() {
+    std::terminate();
+  }
+}  // namespace extensions

--- a/core/extensions/impl/misc_extension.hpp
+++ b/core/extensions/impl/misc_extension.hpp
@@ -1,0 +1,21 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_MISC_EXTENSION_HPP
+#define KAGOME_MISC_EXTENSION_HPP
+
+namespace extensions {
+  /**
+   * Implements miscellaneous extension functions
+   */
+  class MiscExtension {
+   public:
+    uint64_t ext_chain_id() {
+      std::terminate();
+    }
+  };
+}  // namespace extensions
+
+#endif  // KAGOME_MISC_EXTENSION_HPP

--- a/core/extensions/impl/misc_extension.hpp
+++ b/core/extensions/impl/misc_extension.hpp
@@ -12,9 +12,7 @@ namespace extensions {
    */
   class MiscExtension {
    public:
-    uint64_t ext_chain_id() {
-      std::terminate();
-    }
+    uint64_t ext_chain_id();
   };
 }  // namespace extensions
 

--- a/core/extensions/impl/misc_extension.hpp
+++ b/core/extensions/impl/misc_extension.hpp
@@ -8,7 +8,7 @@
 
 #include <cstdint>
 
-namespace extensions {
+namespace kagome::extensions {
   /**
    * Implements miscellaneous extension functions
    */

--- a/core/extensions/impl/misc_extension.hpp
+++ b/core/extensions/impl/misc_extension.hpp
@@ -6,6 +6,8 @@
 #ifndef KAGOME_MISC_EXTENSION_HPP
 #define KAGOME_MISC_EXTENSION_HPP
 
+#include <cstdint>
+
 namespace extensions {
   /**
    * Implements miscellaneous extension functions

--- a/core/extensions/impl/sandboxing_extension.cpp
+++ b/core/extensions/impl/sandboxing_extension.cpp
@@ -12,44 +12,40 @@ namespace extensions {
       uint32_t instance_idx) {
     std::terminate();
   }
+
   uint32_t SandboxingExtension::ext_sandbox_instantiate(
-      std::function<uint64_t(const uint8_t *serialized_args,
-                             size_t serialized_args_length,
-                             size_t state,
-                             size_t func_index)> dispatch_func,
-      const uint8_t *wasm_ptr,
-      size_t wasm_length,
-      const uint8_t *imports_ptr,
-      size_t imports_length,
+      SandoxDispatchFuncType dispatch_func, const uint8_t *wasm_ptr,
+      size_t wasm_length, const uint8_t *imports_ptr, size_t imports_length,
       size_t state) {
     std::terminate();
   }
-  uint32_t SandboxingExtension::ext_sandbox_invoke(uint32_t instance_idx,
-                                                   const uint8_t *export_ptr,
-                                                   size_t export_len,
-                                                   const uint8_t *args_ptr,
-                                                   size_t args_len,
-                                                   uint8_t *return_val_ptr,
-                                                   size_t return_val_len,
-                                                   size_t state) {
+
+  uint32_t SandboxingExtension::ext_sandbox_invoke(
+      uint32_t instance_idx, const uint8_t *export_ptr, size_t export_len,
+      const uint8_t *args_ptr, size_t args_len, uint8_t *return_val_ptr,
+      size_t return_val_len, size_t state) {
     std::terminate();
   }
+
   uint32_t SandboxingExtension::ext_sandbox_memory_get(uint32_t memory_idx,
                                                        uint32_t offset,
                                                        uint8_t *buf_ptr,
                                                        size_t buf_length) {
     std::terminate();
   }
+
   uint32_t SandboxingExtension::ext_sandbox_memory_new(uint32_t initial,
                                                        uint32_t maximum) {
     std::terminate();
   }
+
   uint32_t SandboxingExtension::ext_sandbox_memory_set(uint32_t memory_idx,
                                                        uint32_t offset,
                                                        const uint8_t *val_ptr,
                                                        size_t val_len) {
     std::terminate();
   }
+
   void SandboxingExtension::ext_sandbox_memory_teardown(uint32_t memory_idx) {
     std::terminate();
   }

--- a/core/extensions/impl/sandboxing_extension.cpp
+++ b/core/extensions/impl/sandboxing_extension.cpp
@@ -7,14 +7,14 @@
 
 #include "extensions/impl/sandboxing_extension.hpp"
 
-namespace extensions {
+namespace kagome::extensions {
   void SandboxingExtension::ext_sandbox_instance_teardown(
       uint32_t instance_idx) {
     std::terminate();
   }
 
   uint32_t SandboxingExtension::ext_sandbox_instantiate(
-      SandoxDispatchFuncType dispatch_func, const uint8_t *wasm_ptr,
+      const SandoxDispatchFuncType &dispatch_func, const uint8_t *wasm_ptr,
       size_t wasm_length, const uint8_t *imports_ptr, size_t imports_length,
       size_t state) {
     std::terminate();

--- a/core/extensions/impl/sandboxing_extension.cpp
+++ b/core/extensions/impl/sandboxing_extension.cpp
@@ -2,53 +2,55 @@
  * Copyright Soramitsu Co., Ltd. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
- 
+
 #include <exception>
 
 #include "extensions/impl/sandboxing_extension.hpp"
 
 namespace extensions {
-  void SandboxingExtension::ext_sandbox_instance_teardown(uint32_t instance_idx) {
+  void SandboxingExtension::ext_sandbox_instance_teardown(
+      uint32_t instance_idx) {
     std::terminate();
   }
   uint32_t SandboxingExtension::ext_sandbox_instantiate(
       std::function<uint64_t(const uint8_t *serialized_args,
-                             uint32_t serialized_args_length,
-                             uint32_t state,
-                             uint32_t func_index)> dispatch_func,
+                             size_t serialized_args_length,
+                             size_t state,
+                             size_t func_index)> dispatch_func,
       const uint8_t *wasm_ptr,
-      uint32_t wasm_length,
+      size_t wasm_length,
       const uint8_t *imports_ptr,
-      uint32_t imports_length,
-      uint32_t state) {
+      size_t imports_length,
+      size_t state) {
     std::terminate();
   }
   uint32_t SandboxingExtension::ext_sandbox_invoke(uint32_t instance_idx,
-                              const uint8_t *export_ptr,
-                              uint32_t export_len,
-                              const uint8_t *args_ptr,
-                              uint32_t args_len,
-                              uint8_t *return_val_ptr,
-                              uint32_t return_val_len,
-                              uint32_t state) {
+                                                   const uint8_t *export_ptr,
+                                                   size_t export_len,
+                                                   const uint8_t *args_ptr,
+                                                   size_t args_len,
+                                                   uint8_t *return_val_ptr,
+                                                   size_t return_val_len,
+                                                   size_t state) {
     std::terminate();
   }
   uint32_t SandboxingExtension::ext_sandbox_memory_get(uint32_t memory_idx,
-                                  uint32_t offset,
-                                  uint8_t *buf_ptr,
-                                  uint32_t buf_length) {
+                                                       uint32_t offset,
+                                                       uint8_t *buf_ptr,
+                                                       size_t buf_length) {
     std::terminate();
   }
-  uint32_t SandboxingExtension::ext_sandbox_memory_new(uint32_t initial, uint32_t maximum) {
+  uint32_t SandboxingExtension::ext_sandbox_memory_new(uint32_t initial,
+                                                       uint32_t maximum) {
     std::terminate();
   }
   uint32_t SandboxingExtension::ext_sandbox_memory_set(uint32_t memory_idx,
-                                  uint32_t offset,
-                                  const uint8_t *val_ptr,
-                                  uint32_t val_len) {
+                                                       uint32_t offset,
+                                                       const uint8_t *val_ptr,
+                                                       size_t val_len) {
     std::terminate();
   }
   void SandboxingExtension::ext_sandbox_memory_teardown(uint32_t memory_idx) {
     std::terminate();
   }
-}
+}  // namespace extensions

--- a/core/extensions/impl/sandboxing_extension.cpp
+++ b/core/extensions/impl/sandboxing_extension.cpp
@@ -1,0 +1,54 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+ 
+#include <exception>
+
+#include "extensions/impl/sandboxing_extension.hpp"
+
+namespace extensions {
+  void SandboxingExtension::ext_sandbox_instance_teardown(uint32_t instance_idx) {
+    std::terminate();
+  }
+  uint32_t SandboxingExtension::ext_sandbox_instantiate(
+      std::function<uint64_t(const uint8_t *serialized_args,
+                             uint32_t serialized_args_length,
+                             uint32_t state,
+                             uint32_t func_index)> dispatch_func,
+      const uint8_t *wasm_ptr,
+      uint32_t wasm_length,
+      const uint8_t *imports_ptr,
+      uint32_t imports_length,
+      uint32_t state) {
+    std::terminate();
+  }
+  uint32_t SandboxingExtension::ext_sandbox_invoke(uint32_t instance_idx,
+                              const uint8_t *export_ptr,
+                              uint32_t export_len,
+                              const uint8_t *args_ptr,
+                              uint32_t args_len,
+                              uint8_t *return_val_ptr,
+                              uint32_t return_val_len,
+                              uint32_t state) {
+    std::terminate();
+  }
+  uint32_t SandboxingExtension::ext_sandbox_memory_get(uint32_t memory_idx,
+                                  uint32_t offset,
+                                  uint8_t *buf_ptr,
+                                  uint32_t buf_length) {
+    std::terminate();
+  }
+  uint32_t SandboxingExtension::ext_sandbox_memory_new(uint32_t initial, uint32_t maximum) {
+    std::terminate();
+  }
+  uint32_t SandboxingExtension::ext_sandbox_memory_set(uint32_t memory_idx,
+                                  uint32_t offset,
+                                  const uint8_t *val_ptr,
+                                  uint32_t val_len) {
+    std::terminate();
+  }
+  void SandboxingExtension::ext_sandbox_memory_teardown(uint32_t memory_idx) {
+    std::terminate();
+  }
+}

--- a/core/extensions/impl/sandboxing_extension.hpp
+++ b/core/extensions/impl/sandboxing_extension.hpp
@@ -14,9 +14,7 @@ namespace extensions {
    */
   class SandboxingExtension {
    public:
-    void ext_sandbox_instance_teardown(uint32_t instance_idx) {
-      std::terminate();
-    }
+    void ext_sandbox_instance_teardown(uint32_t instance_idx);
     uint32_t ext_sandbox_instantiate(
         std::function<uint64_t(const uint8_t *serialized_args,
                                uint32_t serialized_args_length,
@@ -26,9 +24,7 @@ namespace extensions {
         uint32_t wasm_length,
         const uint8_t *imports_ptr,
         uint32_t imports_length,
-        uint32_t state) {
-      std::terminate();
-    }
+        uint32_t state);
     uint32_t ext_sandbox_invoke(uint32_t instance_idx,
                                 const uint8_t *export_ptr,
                                 uint32_t export_len,
@@ -36,27 +32,17 @@ namespace extensions {
                                 uint32_t args_len,
                                 uint8_t *return_val_ptr,
                                 uint32_t return_val_len,
-                                uint32_t state) {
-      std::terminate();
-    }
+                                uint32_t state);
     uint32_t ext_sandbox_memory_get(uint32_t memory_idx,
                                     uint32_t offset,
                                     uint8_t *buf_ptr,
-                                    uint32_t buf_length) {
-      std::terminate();
-    }
-    uint32_t ext_sandbox_memory_new(uint32_t initial, uint32_t maximum) {
-      std::terminate();
-    }
+                                    uint32_t buf_length);
+    uint32_t ext_sandbox_memory_new(uint32_t initial, uint32_t maximum);
     uint32_t ext_sandbox_memory_set(uint32_t memory_idx,
                                     uint32_t offset,
                                     const uint8_t *val_ptr,
-                                    uint32_t val_len) {
-      std::terminate();
-    }
-    void ext_sandbox_memory_teardown(uint32_t memory_idx) {
-      std::terminate();
-    }
+                                    uint32_t val_len);
+    void ext_sandbox_memory_teardown(uint32_t memory_idx);
   };
 }  // namespace extensions
 

--- a/core/extensions/impl/sandboxing_extension.hpp
+++ b/core/extensions/impl/sandboxing_extension.hpp
@@ -13,35 +13,34 @@ namespace extensions {
    * Implements extension functions related to sandboxing
    */
   class SandboxingExtension {
+   private:
+    using SandoxDispatchFuncType = std::function<uint64_t(
+        const uint8_t *serialized_args, size_t serialized_args_length,
+        size_t state, size_t func_index)>;
+
    public:
     void ext_sandbox_instance_teardown(uint32_t instance_idx);
-    uint32_t ext_sandbox_instantiate(
-        std::function<uint64_t(const uint8_t *serialized_args,
-                               size_t serialized_args_length,
-                               size_t state,
-                               size_t func_index)> dispatch_func,
-        const uint8_t *wasm_ptr,
-        size_t wasm_length,
-        const uint8_t *imports_ptr,
-        size_t imports_length,
-        size_t state);
+
+    uint32_t ext_sandbox_instantiate(SandoxDispatchFuncType dispatch_func,
+                                     const uint8_t *wasm_ptr,
+                                     size_t wasm_length,
+                                     const uint8_t *imports_ptr,
+                                     size_t imports_length, size_t state);
+
     uint32_t ext_sandbox_invoke(uint32_t instance_idx,
-                                const uint8_t *export_ptr,
-                                size_t export_len,
-                                const uint8_t *args_ptr,
-                                size_t args_len,
-                                uint8_t *return_val_ptr,
-                                size_t return_val_len,
+                                const uint8_t *export_ptr, size_t export_len,
+                                const uint8_t *args_ptr, size_t args_len,
+                                uint8_t *return_val_ptr, size_t return_val_len,
                                 size_t state);
-    uint32_t ext_sandbox_memory_get(uint32_t memory_idx,
-                                    uint32_t offset,
-                                    uint8_t *buf_ptr,
-                                    size_t buf_length);
+
+    uint32_t ext_sandbox_memory_get(uint32_t memory_idx, uint32_t offset,
+                                    uint8_t *buf_ptr, size_t buf_length);
+
     uint32_t ext_sandbox_memory_new(uint32_t initial, uint32_t maximum);
-    uint32_t ext_sandbox_memory_set(uint32_t memory_idx,
-                                    uint32_t offset,
-                                    const uint8_t *val_ptr,
-                                    size_t val_len);
+
+    uint32_t ext_sandbox_memory_set(uint32_t memory_idx, uint32_t offset,
+                                    const uint8_t *val_ptr, size_t val_len);
+
     void ext_sandbox_memory_teardown(uint32_t memory_idx);
   };
 }  // namespace extensions

--- a/core/extensions/impl/sandboxing_extension.hpp
+++ b/core/extensions/impl/sandboxing_extension.hpp
@@ -9,7 +9,7 @@
 #include <cstdint>
 #include <functional>
 
-namespace extensions {
+namespace kagome::extensions {
   /**
    * Implements extension functions related to sandboxing
    */
@@ -22,11 +22,10 @@ namespace extensions {
    public:
     void ext_sandbox_instance_teardown(uint32_t instance_idx);
 
-    uint32_t ext_sandbox_instantiate(SandoxDispatchFuncType dispatch_func,
-                                     const uint8_t *wasm_ptr,
-                                     size_t wasm_length,
-                                     const uint8_t *imports_ptr,
-                                     size_t imports_length, size_t state);
+    uint32_t ext_sandbox_instantiate(
+        const SandoxDispatchFuncType &dispatch_func, const uint8_t *wasm_ptr,
+        size_t wasm_length, const uint8_t *imports_ptr, size_t imports_length,
+        size_t state);
 
     uint32_t ext_sandbox_invoke(uint32_t instance_idx,
                                 const uint8_t *export_ptr, size_t export_len,

--- a/core/extensions/impl/sandboxing_extension.hpp
+++ b/core/extensions/impl/sandboxing_extension.hpp
@@ -17,31 +17,31 @@ namespace extensions {
     void ext_sandbox_instance_teardown(uint32_t instance_idx);
     uint32_t ext_sandbox_instantiate(
         std::function<uint64_t(const uint8_t *serialized_args,
-                               uint32_t serialized_args_length,
-                               uint32_t state,
-                               uint32_t func_index)> dispatch_func,
+                               size_t serialized_args_length,
+                               size_t state,
+                               size_t func_index)> dispatch_func,
         const uint8_t *wasm_ptr,
-        uint32_t wasm_length,
+        size_t wasm_length,
         const uint8_t *imports_ptr,
-        uint32_t imports_length,
-        uint32_t state);
+        size_t imports_length,
+        size_t state);
     uint32_t ext_sandbox_invoke(uint32_t instance_idx,
                                 const uint8_t *export_ptr,
-                                uint32_t export_len,
+                                size_t export_len,
                                 const uint8_t *args_ptr,
-                                uint32_t args_len,
+                                size_t args_len,
                                 uint8_t *return_val_ptr,
-                                uint32_t return_val_len,
-                                uint32_t state);
+                                size_t return_val_len,
+                                size_t state);
     uint32_t ext_sandbox_memory_get(uint32_t memory_idx,
                                     uint32_t offset,
                                     uint8_t *buf_ptr,
-                                    uint32_t buf_length);
+                                    size_t buf_length);
     uint32_t ext_sandbox_memory_new(uint32_t initial, uint32_t maximum);
     uint32_t ext_sandbox_memory_set(uint32_t memory_idx,
                                     uint32_t offset,
                                     const uint8_t *val_ptr,
-                                    uint32_t val_len);
+                                    size_t val_len);
     void ext_sandbox_memory_teardown(uint32_t memory_idx);
   };
 }  // namespace extensions

--- a/core/extensions/impl/sandboxing_extension.hpp
+++ b/core/extensions/impl/sandboxing_extension.hpp
@@ -6,6 +6,7 @@
 #ifndef KAGOME_SANDBOXING_EXTENSION_HPP
 #define KAGOME_SANDBOXING_EXTENSION_HPP
 
+#include <cstdint>
 #include <functional>
 
 namespace extensions {

--- a/core/extensions/impl/sandboxing_extension.hpp
+++ b/core/extensions/impl/sandboxing_extension.hpp
@@ -1,0 +1,63 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_SANDBOXING_EXTENSION_HPP
+#define KAGOME_SANDBOXING_EXTENSION_HPP
+
+#include <functional>
+
+namespace extensions {
+  /**
+   * Implements extension functions related to sandboxing
+   */
+  class SandboxingExtension {
+   public:
+    void ext_sandbox_instance_teardown(uint32_t instance_idx) {
+      std::terminate();
+    }
+    uint32_t ext_sandbox_instantiate(
+        std::function<uint64_t(const uint8_t *serialized_args,
+                               uint32_t serialized_args_length,
+                               uint32_t state,
+                               uint32_t func_index)> dispatch_func,
+        const uint8_t *wasm_ptr,
+        uint32_t wasm_length,
+        const uint8_t *imports_ptr,
+        uint32_t imports_length,
+        uint32_t state) {
+      std::terminate();
+    }
+    uint32_t ext_sandbox_invoke(uint32_t instance_idx,
+                                const uint8_t *export_ptr,
+                                uint32_t export_len,
+                                const uint8_t *args_ptr,
+                                uint32_t args_len,
+                                uint8_t *return_val_ptr,
+                                uint32_t return_val_len,
+                                uint32_t state) {
+      std::terminate();
+    }
+    uint32_t ext_sandbox_memory_get(uint32_t memory_idx,
+                                    uint32_t offset,
+                                    uint8_t *buf_ptr,
+                                    uint32_t buf_length) {
+      std::terminate();
+    }
+    uint32_t ext_sandbox_memory_new(uint32_t initial, uint32_t maximum) {
+      std::terminate();
+    }
+    uint32_t ext_sandbox_memory_set(uint32_t memory_idx,
+                                    uint32_t offset,
+                                    const uint8_t *val_ptr,
+                                    uint32_t val_len) {
+      std::terminate();
+    }
+    void ext_sandbox_memory_teardown(uint32_t memory_idx) {
+      std::terminate();
+    }
+  };
+}  // namespace extensions
+
+#endif  // KAGOME_SANDBOXING_EXTENSION_HPP

--- a/core/extensions/impl/storage_extension.cpp
+++ b/core/extensions/impl/storage_extension.cpp
@@ -1,0 +1,101 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <exception>
+
+#include "extensions/impl/storage_extension.hpp"
+
+namespace extensions {
+  uint8_t *StorageExtension::ext_child_storage_root(
+      const uint8_t *storage_key_data,
+      uint32_t storage_key_length,
+      uint32_t *written) {
+    std::terminate();
+  }
+  void StorageExtension::ext_clear_child_storage(
+      const uint8_t *storage_key_data,
+      uint32_t storage_key_length,
+      const uint8_t *key_data,
+      uint32_t key_length) {
+    std::terminate();
+  }
+  void StorageExtension::ext_clear_prefix(const uint8_t *prefix_data,
+                                          uint32_t prefix_length) {
+    std::terminate();
+  }
+  void StorageExtension::ext_clear_storage(const uint8_t *key_data,
+                                           uint32_t key_length) {
+    std::terminate();
+  }
+  uint32_t StorageExtension::ext_exists_child_storage(
+      const uint8_t *storage_key_data,
+      uint32_t storage_key_length,
+      const uint8_t *key_data,
+      uint32_t key_length) {
+    std::terminate();
+  }
+  uint8_t *StorageExtension::ext_get_allocated_child_storage(
+      const uint8_t *storage_key_data,
+      uint32_t storage_key_length,
+      const uint8_t *key_data,
+      uint32_t key_length,
+      uint32_t *written) {
+    std::terminate();
+  }
+  uint8_t *StorageExtension::ext_get_allocated_storage(const uint8_t *key_data,
+                                                       uint32_t key_length,
+                                                       uint32_t *written) {
+    std::terminate();
+  }
+  uint32_t StorageExtension::ext_get_child_storage_into(
+      const uint8_t *storage_key_data,
+      uint32_t storage_key_length,
+      const uint8_t *key_data,
+      uint32_t key_length,
+      uint8_t *value_data,
+      uint32_t value_length,
+      uint32_t value_offset) {
+    std::terminate();
+  }
+  uint32_t StorageExtension::ext_get_storage_into(const uint8_t *key_data,
+                                                  uint32_t key_length,
+                                                  uint8_t *value_data,
+                                                  uint32_t value_length,
+                                                  uint32_t value_offset) {
+    std::terminate();
+  }
+  void StorageExtension::ext_kill_child_storage(const uint8_t *storage_key_data,
+                                                uint32_t storage_key_length) {
+    std::terminate();
+  }
+  void StorageExtension::ext_set_child_storage(const uint8_t *storage_key_data,
+                                               uint32_t storage_key_length,
+                                               const uint8_t *key_data,
+                                               uint32_t key_length,
+                                               const uint8_t *value_data,
+                                               uint32_t value_length) {
+    std::terminate();
+  }
+  void StorageExtension::ext_set_storage(const uint8_t *key_data,
+                                         uint32_t key_length,
+                                         const uint8_t *value_data,
+                                         uint32_t value_length) {
+    std::terminate();
+  }
+  uint32_t StorageExtension::ext_storage_changes_root(
+      const uint8_t *parent_hash_data,
+      uint32_t parent_hash_len,
+      uint64_t parent_num,
+      uint8_t *result) {
+    std::terminate();
+  }
+  void StorageExtension::ext_storage_root(uint8_t *result) {
+    std::terminate();
+  }
+  uint32_t StorageExtension::ext_exists_storage(const uint8_t *key_data,
+                                                uint32_t key_length) {
+    std::terminate();
+  }
+}  // namespace extensions

--- a/core/extensions/impl/storage_extension.cpp
+++ b/core/extensions/impl/storage_extension.cpp
@@ -7,7 +7,7 @@
 
 #include "extensions/impl/storage_extension.hpp"
 
-namespace extensions {
+namespace kagome::extensions {
   uint8_t *StorageExtension::ext_child_storage_root(
       const uint8_t *storage_key_data, uint32_t storage_key_length,
       uint32_t *written) {

--- a/core/extensions/impl/storage_extension.cpp
+++ b/core/extensions/impl/storage_extension.cpp
@@ -9,56 +9,52 @@
 
 namespace extensions {
   uint8_t *StorageExtension::ext_child_storage_root(
-      const uint8_t *storage_key_data,
-      uint32_t storage_key_length,
+      const uint8_t *storage_key_data, uint32_t storage_key_length,
       uint32_t *written) {
     std::terminate();
   }
+
   void StorageExtension::ext_clear_child_storage(
-      const uint8_t *storage_key_data,
-      uint32_t storage_key_length,
-      const uint8_t *key_data,
-      uint32_t key_length) {
+      const uint8_t *storage_key_data, uint32_t storage_key_length,
+      const uint8_t *key_data, uint32_t key_length) {
     std::terminate();
   }
+
   void StorageExtension::ext_clear_prefix(const uint8_t *prefix_data,
                                           uint32_t prefix_length) {
     std::terminate();
   }
+
   void StorageExtension::ext_clear_storage(const uint8_t *key_data,
                                            uint32_t key_length) {
     std::terminate();
   }
+
   uint32_t StorageExtension::ext_exists_child_storage(
-      const uint8_t *storage_key_data,
-      uint32_t storage_key_length,
-      const uint8_t *key_data,
-      uint32_t key_length) {
+      const uint8_t *storage_key_data, uint32_t storage_key_length,
+      const uint8_t *key_data, uint32_t key_length) {
     std::terminate();
   }
+
   uint8_t *StorageExtension::ext_get_allocated_child_storage(
-      const uint8_t *storage_key_data,
-      uint32_t storage_key_length,
-      const uint8_t *key_data,
-      uint32_t key_length,
-      uint32_t *written) {
+      const uint8_t *storage_key_data, uint32_t storage_key_length,
+      const uint8_t *key_data, uint32_t key_length, uint32_t *written) {
     std::terminate();
   }
+
   uint8_t *StorageExtension::ext_get_allocated_storage(const uint8_t *key_data,
                                                        uint32_t key_length,
                                                        uint32_t *written) {
     std::terminate();
   }
+
   uint32_t StorageExtension::ext_get_child_storage_into(
-      const uint8_t *storage_key_data,
-      uint32_t storage_key_length,
-      const uint8_t *key_data,
-      uint32_t key_length,
-      uint8_t *value_data,
-      uint32_t value_length,
-      uint32_t value_offset) {
+      const uint8_t *storage_key_data, uint32_t storage_key_length,
+      const uint8_t *key_data, uint32_t key_length, uint8_t *value_data,
+      uint32_t value_length, uint32_t value_offset) {
     std::terminate();
   }
+
   uint32_t StorageExtension::ext_get_storage_into(const uint8_t *key_data,
                                                   uint32_t key_length,
                                                   uint8_t *value_data,
@@ -66,10 +62,12 @@ namespace extensions {
                                                   uint32_t value_offset) {
     std::terminate();
   }
+
   void StorageExtension::ext_kill_child_storage(const uint8_t *storage_key_data,
                                                 uint32_t storage_key_length) {
     std::terminate();
   }
+
   void StorageExtension::ext_set_child_storage(const uint8_t *storage_key_data,
                                                uint32_t storage_key_length,
                                                const uint8_t *key_data,
@@ -78,22 +76,24 @@ namespace extensions {
                                                uint32_t value_length) {
     std::terminate();
   }
+
   void StorageExtension::ext_set_storage(const uint8_t *key_data,
                                          uint32_t key_length,
                                          const uint8_t *value_data,
                                          uint32_t value_length) {
     std::terminate();
   }
+
   uint32_t StorageExtension::ext_storage_changes_root(
-      const uint8_t *parent_hash_data,
-      uint32_t parent_hash_len,
-      uint64_t parent_num,
-      uint8_t *result) {
+      const uint8_t *parent_hash_data, uint32_t parent_hash_len,
+      uint64_t parent_num, uint8_t *result) {
     std::terminate();
   }
+
   void StorageExtension::ext_storage_root(uint8_t *result) {
     std::terminate();
   }
+
   uint32_t StorageExtension::ext_exists_storage(const uint8_t *key_data,
                                                 uint32_t key_length) {
     std::terminate();

--- a/core/extensions/impl/storage_extension.hpp
+++ b/core/extensions/impl/storage_extension.hpp
@@ -1,0 +1,99 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef KAGOME_STORAGE_EXTENSION_HPP
+#define KAGOME_STORAGE_EXTENSION_HPP
+
+namespace extensions {
+  /**
+   * Implements extension functions related to storage
+   */
+  class StorageExtension {
+   public:
+    uint8_t *ext_child_storage_root(const uint8_t *storage_key_data,
+                                    uint32_t storage_key_length,
+                                    uint32_t *written) {
+      std::terminate();
+    }
+    void ext_clear_child_storage(const uint8_t *storage_key_data,
+                                 uint32_t storage_key_length,
+                                 const uint8_t *key_data,
+                                 uint32_t key_length) {
+      std::terminate();
+    }
+    void ext_clear_prefix(const uint8_t *prefix_data, uint32_t prefix_length) {
+      std::terminate();
+    }
+    void ext_clear_storage(const uint8_t *key_data, uint32_t key_length) {
+      std::terminate();
+    }
+    uint32_t ext_exists_child_storage(const uint8_t *storage_key_data,
+                                      uint32_t storage_key_length,
+                                      const uint8_t *key_data,
+                                      uint32_t key_length) {
+      std::terminate();
+    }
+    uint8_t *ext_get_allocated_child_storage(const uint8_t *storage_key_data,
+                                             uint32_t storage_key_length,
+                                             const uint8_t *key_data,
+                                             uint32_t key_length,
+                                             uint32_t *written) {
+      std::terminate();
+    }
+    uint8_t *ext_get_allocated_storage(const uint8_t *key_data,
+                                       uint32_t key_length,
+                                       uint32_t *written) {
+      std::terminate();
+    }
+    uint32_t ext_get_child_storage_into(const uint8_t *storage_key_data,
+                                        uint32_t storage_key_length,
+                                        const uint8_t *key_data,
+                                        uint32_t key_length,
+                                        uint8_t *value_data,
+                                        uint32_t value_length,
+                                        uint32_t value_offset) {
+      std::terminate();
+    }
+    uint32_t ext_get_storage_into(const uint8_t *key_data,
+                                  uint32_t key_length,
+                                  uint8_t *value_data,
+                                  uint32_t value_length,
+                                  uint32_t value_offset) {
+      std::terminate();
+    }
+    void ext_kill_child_storage(const uint8_t *storage_key_data,
+                                uint32_t storage_key_length) {
+      std::terminate();
+    }
+    void ext_set_child_storage(const uint8_t *storage_key_data,
+                               uint32_t storage_key_length,
+                               const uint8_t *key_data,
+                               uint32_t key_length,
+                               uint8_t *value_data,
+                               uint32_t value_length) {
+      std::terminate();
+    }
+    void ext_set_storage(const uint8_t *key_data,
+                         uint32_t key_length,
+                         uint8_t *value_data,
+                         uint32_t value_length) {
+      std::terminate();
+    }
+    uint32_t ext_storage_changes_root(const uint8_t *parent_hash_data,
+                                      uint32_t parent_hash_len,
+                                      uint64_t parent_num,
+                                      uint8_t *result) {
+      std::terminate();
+    }
+    void ext_storage_root(uint8_t *result) {
+      std::terminate();
+    }
+    uint32_t ext_exists_storage(const uint8_t *key_data, uint32_t key_length) {
+      std::terminate();
+    }
+  };
+}  // namespace extensions
+
+#endif  // KAGOME_STORAGE_EXTENSION_HPP

--- a/core/extensions/impl/storage_extension.hpp
+++ b/core/extensions/impl/storage_extension.hpp
@@ -15,53 +15,56 @@ namespace extensions {
     uint8_t *ext_child_storage_root(const uint8_t *storage_key_data,
                                     uint32_t storage_key_length,
                                     uint32_t *written);
+
     void ext_clear_child_storage(const uint8_t *storage_key_data,
                                  uint32_t storage_key_length,
-                                 const uint8_t *key_data,
-                                 uint32_t key_length);
+                                 const uint8_t *key_data, uint32_t key_length);
+
     void ext_clear_prefix(const uint8_t *prefix_data, uint32_t prefix_length);
+
     void ext_clear_storage(const uint8_t *key_data, uint32_t key_length);
+
     uint32_t ext_exists_child_storage(const uint8_t *storage_key_data,
                                       uint32_t storage_key_length,
                                       const uint8_t *key_data,
                                       uint32_t key_length);
+
     uint8_t *ext_get_allocated_child_storage(const uint8_t *storage_key_data,
                                              uint32_t storage_key_length,
                                              const uint8_t *key_data,
                                              uint32_t key_length,
                                              uint32_t *written);
+
     uint8_t *ext_get_allocated_storage(const uint8_t *key_data,
-                                       uint32_t key_length,
-                                       uint32_t *written);
-    uint32_t ext_get_child_storage_into(const uint8_t *storage_key_data,
-                                        uint32_t storage_key_length,
-                                        const uint8_t *key_data,
-                                        uint32_t key_length,
-                                        uint8_t *value_data,
-                                        uint32_t value_length,
-                                        uint32_t value_offset);
-    uint32_t ext_get_storage_into(const uint8_t *key_data,
-                                  uint32_t key_length,
-                                  uint8_t *value_data,
-                                  uint32_t value_length,
+                                       uint32_t key_length, uint32_t *written);
+
+    uint32_t ext_get_child_storage_into(
+        const uint8_t *storage_key_data, uint32_t storage_key_length,
+        const uint8_t *key_data, uint32_t key_length, uint8_t *value_data,
+        uint32_t value_length, uint32_t value_offset);
+
+    uint32_t ext_get_storage_into(const uint8_t *key_data, uint32_t key_length,
+                                  uint8_t *value_data, uint32_t value_length,
                                   uint32_t value_offset);
+
     void ext_kill_child_storage(const uint8_t *storage_key_data,
                                 uint32_t storage_key_length);
+
     void ext_set_child_storage(const uint8_t *storage_key_data,
                                uint32_t storage_key_length,
-                               const uint8_t *key_data,
-                               uint32_t key_length,
+                               const uint8_t *key_data, uint32_t key_length,
                                const uint8_t *value_data,
                                uint32_t value_length);
-    void ext_set_storage(const uint8_t *key_data,
-                         uint32_t key_length,
-                         const uint8_t *value_data,
-                         uint32_t value_length);
+
+    void ext_set_storage(const uint8_t *key_data, uint32_t key_length,
+                         const uint8_t *value_data, uint32_t value_length);
+
     uint32_t ext_storage_changes_root(const uint8_t *parent_hash_data,
                                       uint32_t parent_hash_len,
-                                      uint64_t parent_num,
-                                      uint8_t *result);
+                                      uint64_t parent_num, uint8_t *result);
+
     void ext_storage_root(uint8_t *result);
+
     uint32_t ext_exists_storage(const uint8_t *key_data, uint32_t key_length);
   };
 }  // namespace extensions

--- a/core/extensions/impl/storage_extension.hpp
+++ b/core/extensions/impl/storage_extension.hpp
@@ -6,6 +6,8 @@
 #ifndef KAGOME_STORAGE_EXTENSION_HPP
 #define KAGOME_STORAGE_EXTENSION_HPP
 
+#include <cstdint>
+
 namespace extensions {
   /**
    * Implements extension functions related to storage

--- a/core/extensions/impl/storage_extension.hpp
+++ b/core/extensions/impl/storage_extension.hpp
@@ -8,7 +8,7 @@
 
 #include <cstdint>
 
-namespace extensions {
+namespace kagome::extensions {
   /**
    * Implements extension functions related to storage
    */

--- a/core/extensions/impl/storage_extension.hpp
+++ b/core/extensions/impl/storage_extension.hpp
@@ -14,85 +14,55 @@ namespace extensions {
    public:
     uint8_t *ext_child_storage_root(const uint8_t *storage_key_data,
                                     uint32_t storage_key_length,
-                                    uint32_t *written) {
-      std::terminate();
-    }
+                                    uint32_t *written);
     void ext_clear_child_storage(const uint8_t *storage_key_data,
                                  uint32_t storage_key_length,
                                  const uint8_t *key_data,
-                                 uint32_t key_length) {
-      std::terminate();
-    }
-    void ext_clear_prefix(const uint8_t *prefix_data, uint32_t prefix_length) {
-      std::terminate();
-    }
-    void ext_clear_storage(const uint8_t *key_data, uint32_t key_length) {
-      std::terminate();
-    }
+                                 uint32_t key_length);
+    void ext_clear_prefix(const uint8_t *prefix_data, uint32_t prefix_length);
+    void ext_clear_storage(const uint8_t *key_data, uint32_t key_length);
     uint32_t ext_exists_child_storage(const uint8_t *storage_key_data,
                                       uint32_t storage_key_length,
                                       const uint8_t *key_data,
-                                      uint32_t key_length) {
-      std::terminate();
-    }
+                                      uint32_t key_length);
     uint8_t *ext_get_allocated_child_storage(const uint8_t *storage_key_data,
                                              uint32_t storage_key_length,
                                              const uint8_t *key_data,
                                              uint32_t key_length,
-                                             uint32_t *written) {
-      std::terminate();
-    }
+                                             uint32_t *written);
     uint8_t *ext_get_allocated_storage(const uint8_t *key_data,
                                        uint32_t key_length,
-                                       uint32_t *written) {
-      std::terminate();
-    }
+                                       uint32_t *written);
     uint32_t ext_get_child_storage_into(const uint8_t *storage_key_data,
                                         uint32_t storage_key_length,
                                         const uint8_t *key_data,
                                         uint32_t key_length,
                                         uint8_t *value_data,
                                         uint32_t value_length,
-                                        uint32_t value_offset) {
-      std::terminate();
-    }
+                                        uint32_t value_offset);
     uint32_t ext_get_storage_into(const uint8_t *key_data,
                                   uint32_t key_length,
                                   uint8_t *value_data,
                                   uint32_t value_length,
-                                  uint32_t value_offset) {
-      std::terminate();
-    }
+                                  uint32_t value_offset);
     void ext_kill_child_storage(const uint8_t *storage_key_data,
-                                uint32_t storage_key_length) {
-      std::terminate();
-    }
+                                uint32_t storage_key_length);
     void ext_set_child_storage(const uint8_t *storage_key_data,
                                uint32_t storage_key_length,
                                const uint8_t *key_data,
                                uint32_t key_length,
-                               uint8_t *value_data,
-                               uint32_t value_length) {
-      std::terminate();
-    }
+                               const uint8_t *value_data,
+                               uint32_t value_length);
     void ext_set_storage(const uint8_t *key_data,
                          uint32_t key_length,
-                         uint8_t *value_data,
-                         uint32_t value_length) {
-      std::terminate();
-    }
+                         const uint8_t *value_data,
+                         uint32_t value_length);
     uint32_t ext_storage_changes_root(const uint8_t *parent_hash_data,
                                       uint32_t parent_hash_len,
                                       uint64_t parent_num,
-                                      uint8_t *result) {
-      std::terminate();
-    }
-    void ext_storage_root(uint8_t *result) {
-      std::terminate();
-    }
-    uint32_t ext_exists_storage(const uint8_t *key_data, uint32_t key_length) {
-      std::terminate();
-    }
+                                      uint8_t *result);
+    void ext_storage_root(uint8_t *result);
+    uint32_t ext_exists_storage(const uint8_t *key_data, uint32_t key_length);
   };
 }  // namespace extensions
 


### PR DESCRIPTION
### Description of the Change

This PR adds interfaces for all the extensions, described in this [doc](https://github.com/w3f/polkadot-re-spec/blob/master/polkadot_re_spec.pdf), chapter 3.4. Rust implementation was used as a reference, most `ext_` functions can be found [here](https://github.com/paritytech/substrate/blob/master/core/sr-io/without_std.rs), while the rest are [here](https://github.com/paritytech/substrate/blob/82744fbb6f4d677f2edfe9d88737c237622c97a4/core/sr-sandbox/without_std.rs).

### Benefits

Ability to start the implementation of the extensions.

### Possible Drawbacks 

None.

### Alternate Designs

Please, pay attention to the fact that Polkadot doc says that pointers are to be 32-bit, while on 64-bit machines they are not. I am not sure if this is a problem, but still.
