### PR TITLE
Feature/misc ext

### DIFF
--- a/core/extensions/impl/misc_extension.cpp
+++ b/core/extensions/impl/misc_extension.cpp
@@ -8,7 +8,11 @@
 #include "extensions/impl/misc_extension.hpp"
 
 namespace kagome::extensions {
+
+  MiscExtension::MiscExtension(uint64_t chain_id):
+    chain_id_ {chain_id} {}
+
   uint64_t MiscExtension::ext_chain_id() {
-    std::terminate();
+    return chain_id_;
   }
 }  // namespace extensions

--- a/core/extensions/impl/misc_extension.hpp
+++ b/core/extensions/impl/misc_extension.hpp
@@ -17,10 +17,13 @@ namespace kagome::extensions {
     MiscExtension() = default;
     explicit MiscExtension(uint64_t chain_id);
 
+    /**
+     * @return id (a 64-bit unsigned integer) of the current chain
+     */
     uint64_t ext_chain_id();
 
    private:
-    uint64_t chain_id_ = 42;
+    const uint64_t chain_id_ = 42;
   };
 }  // namespace extensions
 

--- a/core/extensions/impl/misc_extension.hpp
+++ b/core/extensions/impl/misc_extension.hpp
@@ -14,7 +14,13 @@ namespace kagome::extensions {
    */
   class MiscExtension {
    public:
+    MiscExtension() = default;
+    explicit MiscExtension(uint64_t chain_id);
+
     uint64_t ext_chain_id();
+
+   private:
+    uint64_t chain_id_ = 42;
   };
 }  // namespace extensions
 

--- a/test/core/extensions/CMakeLists.txt
+++ b/test/core/extensions/CMakeLists.txt
@@ -16,3 +16,10 @@ addtest(io_extension_test
 target_link_libraries(io_extension_test
     extensions
     )
+
+addtest(misc_extension_test
+    misc_extension_test.cpp
+    )
+target_link_libraries(misc_extension_test
+    misc_extension
+    )

--- a/test/core/extensions/misc_extension_test.cpp
+++ b/test/core/extensions/misc_extension_test.cpp
@@ -6,6 +6,11 @@
 #include <gtest/gtest.h>
 #include "extensions/impl/misc_extension.hpp"
 
+/**
+ * @given a chain id
+ * @when initializing misc extention
+ * @then ext_chain_id return the chain id
+ */
 TEST(MiscExt, Init) {
   kagome::extensions::MiscExtension m;
   ASSERT_EQ(m.ext_chain_id(), 42);

--- a/test/core/extensions/misc_extension_test.cpp
+++ b/test/core/extensions/misc_extension_test.cpp
@@ -1,0 +1,15 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+#include "extensions/impl/misc_extension.hpp"
+
+TEST(MiscExt, Init) {
+  kagome::extensions::MiscExtension m;
+  ASSERT_EQ(m.ext_chain_id(), 42);
+
+  kagome::extensions::MiscExtension m2(34);
+  ASSERT_EQ(m2.ext_chain_id(), 34);
+}


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Add implementation of misc extension. It contains ext_chain_id method, which returns the current chain identifier (a 64-bit unsigned integer). For now, the integer is just passed in the extension constructor.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
It is a part of PRE specification.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*
Provided in the code.
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*
Actually, I do not have knowledge yet of where exactly from the chain ID is meant to be taken, and thus I cannot be sure that just passing an integer in the constructor is enough. By the way, default value of 42 was taken from Rust implementation of substrate, where it is the only value the method returns. It appears to be that it may be changed in custom implementation of Externals trait.
<!-- Explain what other alternates were considered and why the proposed version was selected -->
